### PR TITLE
WIP: Prototype for custom responses

### DIFF
--- a/src/Http/SaloonConnector.php
+++ b/src/Http/SaloonConnector.php
@@ -20,6 +20,21 @@ abstract class SaloonConnector implements SaloonConnectorInterface
         CollectsInterceptors;
 
     /**
+     * The response class.
+     *
+     * @var class-string<\Sammyjo20\Saloon\Http\SaloonResponse>|null
+     */
+    protected ?string $response = null;
+
+    /**
+     * Gets the response class.
+     * @return string|null
+     */
+    public function getResponseClass(): ?string {
+        return $this->response;
+    }
+
+    /**
      * Define anything to be added to the connector.
      *
      * @return void

--- a/src/Http/SaloonRequest.php
+++ b/src/Http/SaloonRequest.php
@@ -46,6 +46,13 @@ abstract class SaloonRequest implements SaloonRequestInterface
     private ?SaloonConnector $loadedConnector = null;
 
     /**
+     * The response class.
+     *
+     * @var class-string<\Sammyjo20\Saloon\Http\SaloonResponse>|null
+     */
+    protected ?string $response = null;
+
+    /**
      * Define anything to be added to the request.
      *
      * @return void
@@ -67,6 +74,20 @@ abstract class SaloonRequest implements SaloonRequestInterface
         }
 
         return $this->method;
+    }
+
+    /**
+     * Get the method the class is using.
+     *
+     * @return string
+     */
+    public function getResponseClass(): string
+    {
+        return match (false) {
+            is_null($this->response) => $this->response,
+            is_null($this->loadedConnector?->getResponseClass()) => $this->loadedConnector?->getResponseClass(),
+            default => SaloonResponse::class,
+        };
     }
 
     /**

--- a/src/Managers/RequestManager.php
+++ b/src/Managers/RequestManager.php
@@ -185,7 +185,9 @@ class RequestManager
 
         $shouldGuessStatusFromBody = isset($this->connector->shouldGuessStatusFromBody) || isset($this->request->shouldGuessStatusFromBody);
 
-        $response = new SaloonResponse($requestOptions, $request, $response, $shouldGuessStatusFromBody);
+        $responseClass = $request->getResponseClass();
+
+        $response = new $responseClass($requestOptions, $request, $response, $shouldGuessStatusFromBody);
 
         $response->setMocked($this->isMocking());
 


### PR DESCRIPTION
Related to #11.

This is a prototype and can be tried out at https://github.com/Wulfheart/SaloonWorkbench. It is necessary to have Saloon and SaloonWorkbench in the same directory.
In the end there have to be more tests and a `saloon:response` command. The biggest pain point right now is the lack of typehinting for the response on `$request->send()`. I think it can be solved with docblocks generics like described [here](https://phpstan.org/blog/generics-in-php-using-phpdocs) but I have no idea how to implement it. Any ideas regarding this? 