### PR TITLE
Add default defineEndpoint in base SaloonRequest

### DIFF
--- a/src/Http/SaloonRequest.php
+++ b/src/Http/SaloonRequest.php
@@ -137,6 +137,16 @@ abstract class SaloonRequest implements SaloonRequestInterface
     }
 
     /**
+     * Define the endpoint for the request.
+     *
+     * @return string
+     */
+    public function defineEndpoint(): string
+    {
+        return '';
+    }	
+
+    /**
      * Check if a trait exists on the connector.
      *
      * @param string $trait

--- a/tests/Resources/Requests/DefaultEndpointRequest.php
+++ b/tests/Resources/Requests/DefaultEndpointRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sammyjo20\Saloon\Tests\Resources\Requests;
+
+use Sammyjo20\Saloon\Constants\Saloon;
+use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\Saloon\Tests\Resources\Connectors\TestConnector;
+
+class DefaultEndpointRequest extends SaloonRequest
+{
+    /**
+     * Define the method that the request will use.
+     *
+     * @var string|null
+     */
+    protected ?string $method = Saloon::POST;
+
+    /**
+     * The connector.
+     *
+     * @var string|null
+     */
+    protected ?string $connector = TestConnector::class;
+}

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -10,6 +10,7 @@ use Sammyjo20\Saloon\Tests\Resources\Requests\NoConnectorRequest;
 use Sammyjo20\Saloon\Tests\Resources\Connectors\ExtendedConnector;
 use Sammyjo20\Saloon\Tests\Resources\Requests\InvalidResponseClass;
 use Sammyjo20\Saloon\Exceptions\SaloonInvalidResponseClassException;
+use Sammyjo20\Saloon\Tests\Resources\Requests\DefaultEndpointRequest;
 use Sammyjo20\Saloon\Tests\Resources\Requests\InvalidConnectorRequest;
 use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponsesProvidedException;
 use Sammyjo20\Saloon\Tests\Resources\Requests\ExtendedConnectorRequest;
@@ -113,3 +114,7 @@ test('saloon throws an exception if the custom response is not a response class'
 
     expect($invalidConnectorClassRequest->getResponseClass());
 });
+
+test('defineEndpoint method may be omited in request class to use the base url')
+	->expect(new DefaultEndpointRequest)
+	->getFullRequestUrl()->toBe(apiUrl());


### PR DESCRIPTION
Just got started with this for a graphql integration, works really good 💫 
Not *100% sure* this is an improvement you would like so feel free to decline it 👍 

Since graphql request always targets a root like "www.acme.com/api/graphql" - no appended endpoint - would it make sense to allow to not explicitly repeating defineEndpoint method returning '' every time?
```php
    /**
     * Define the endpoint for the request.
     *
     * @return string
     */
    public function defineEndpoint(): string
    {
        return '';
    }
```    
This PR adds the above to the base class as a default.
   
Also let me know if you prefer keeping all tests in function block style. I just discovered that higher order thing 😄 