### PR TITLE
Added new mock assertions

### DIFF
--- a/src/Clients/BaseMockClient.php
+++ b/src/Clients/BaseMockClient.php
@@ -3,17 +3,15 @@
 namespace Sammyjo20\Saloon\Clients;
 
 use ReflectionClass;
-use Illuminate\Support\Str;
-use Sammyjo20\Saloon\Helpers\ReflectionHelper;
 use Sammyjo20\Saloon\Helpers\URLHelper;
 use Sammyjo20\Saloon\Http\MockResponse;
+use PHPUnit\Framework\Assert as PHPUnit;
 use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\Saloon\Http\SaloonResponse;
 use Sammyjo20\Saloon\Http\SaloonConnector;
+use Sammyjo20\Saloon\Helpers\ReflectionHelper;
 use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponseFoundException;
 use Sammyjo20\Saloon\Exceptions\SaloonInvalidMockResponseCaptureMethodException;
-use Sammyjo20\Saloon\Http\SaloonResponse;
-use PHPUnit\Framework\Assert as PHPUnit;
-
 
 class BaseMockClient
 {

--- a/src/Clients/BaseMockClient.php
+++ b/src/Clients/BaseMockClient.php
@@ -4,26 +4,64 @@ namespace Sammyjo20\Saloon\Clients;
 
 use ReflectionClass;
 use Illuminate\Support\Str;
+use Sammyjo20\Saloon\Helpers\ReflectionHelper;
+use Sammyjo20\Saloon\Helpers\URLHelper;
 use Sammyjo20\Saloon\Http\MockResponse;
 use Sammyjo20\Saloon\Http\SaloonRequest;
 use Sammyjo20\Saloon\Http\SaloonConnector;
 use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponseFoundException;
-use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponsesProvidedException;
 use Sammyjo20\Saloon\Exceptions\SaloonInvalidMockResponseCaptureMethodException;
+use Sammyjo20\Saloon\Http\SaloonResponse;
+use PHPUnit\Framework\Assert as PHPUnit;
+
 
 class BaseMockClient
 {
+    /**
+     * Collection of all the responses that will be sequenced.
+     *
+     * @var array
+     */
     protected array $sequenceResponses = [];
 
+    /**
+     * Collection of responses used only when a connector is called.
+     *
+     * @var array
+     */
     protected array $connectorResponses = [];
 
+    /**
+     * Collection of responses used only when a request is called.
+     *
+     * @var array
+     */
     protected array $requestResponses = [];
 
+    /**
+     * Collection of responses that will run when the request is matched.
+     *
+     * @var array
+     */
     protected array $urlResponses = [];
 
     /**
-     * @param array $responses
-     * @throws SaloonNoMockResponsesProvidedException
+     * Collection of all the recorded responses.
+     *
+     * @var array
+     */
+    protected array $recordedResponses = [];
+
+    /**
+     * The last response the mock client saw.
+     *
+     * @var SaloonResponse|null
+     */
+    protected SaloonResponse|null $lastResponse = null;
+
+    /**
+     * @param array $mockData
+     * @throws SaloonInvalidMockResponseCaptureMethodException
      */
     public function __construct(array $mockData = [])
     {
@@ -134,7 +172,7 @@ class BaseMockClient
     private function guessResponseFromUrl(SaloonRequest $request): ?MockResponse
     {
         foreach ($this->urlResponses as $url => $response) {
-            if (! Str::is(Str::start($url, '*'), $request->getFullRequestUrl())) {
+            if (! URLHelper::matches($url, $request->getFullRequestUrl())) {
                 continue;
             }
 
@@ -152,5 +190,187 @@ class BaseMockClient
     public function isEmpty(): bool
     {
         return empty($this->sequenceResponses) && empty($this->connectorResponses) && empty($this->requestResponses) && empty($this->urlResponses);
+    }
+
+    /**
+     * Record a response.
+     *
+     * @param SaloonResponse $response
+     * @return void
+     */
+    public function recordResponse(SaloonResponse $response): void
+    {
+        $this->recordedResponses[] = $response;
+        $this->lastResponse = $response;
+    }
+
+    /**
+     * Get all the recorded responses
+     *
+     * @return array
+     */
+    public function getRecordedResponses(): array
+    {
+        return $this->recordedResponses;
+    }
+
+    /**
+     * Get the last request that the mock manager sent.
+     *
+     * @return SaloonRequest|null
+     */
+    public function getLastRequest(): ?SaloonRequest
+    {
+        return $this->lastResponse?->getOriginalRequest();
+    }
+
+    /**
+     * Get the last response that the mock manager sent.
+     *
+     * @return SaloonResponse|null
+     */
+    public function getLastResponse(): ?SaloonResponse
+    {
+        return $this->lastResponse;
+    }
+
+    /**
+     * Assert that a given request was sent.
+     *
+     * @param string|callable $value
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function assertSent(string|callable $value): void
+    {
+        $result = $this->checkRequestWasSent($value);
+
+        PHPUnit::assertTrue($result, 'An expected request was not sent.');
+    }
+
+    /**
+     * Assert that a given request was not sent.
+     *
+     * @param string|callable $request
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function assertNotSent(string|callable $request): void
+    {
+        $result = $this->checkRequestWasNotSent($request);
+
+        PHPUnit::assertTrue($result, 'An unexpected request was sent.');
+    }
+
+    /**
+     * Assert JSON data was sent
+     *
+     * @param string $request
+     * @param array $data
+     * @return void
+     * @throws \ReflectionException
+     */
+    public function assertSentJson(string $request, array $data): void
+    {
+        $this->assertSent($request);
+
+        $response = $this->findRequestInHistory($request);
+
+        PHPUnit::assertEquals($response->json(), $data, 'Expected request data was not sent.');
+    }
+
+    /**
+     * Assert that nothing was sent.
+     *
+     * @return void
+     */
+    public function assertNothingSent(): void
+    {
+        PHPUnit::assertEmpty($this->getRecordedResponses(), 'Requests were sent.');
+    }
+
+    /**
+     * Assert a request count has been met.
+     *
+     * @param int $count
+     * @return void
+     */
+    public function assertSentCount(int $count): void
+    {
+        PHPUnit::assertCount($count, $this->getRecordedResponses());
+    }
+
+    /**
+     * Check if a given request was sent
+     *
+     * @param string|callable $request
+     * @return bool
+     * @throws \ReflectionException
+     */
+    protected function checkRequestWasSent(string|callable $request): bool
+    {
+        $result = false;
+
+        if (is_callable($request)) {
+            $result = $request($this->getLastRequest(), $this->getLastResponse());
+        }
+
+        if (is_string($request)) {
+            if (class_exists($request) && ReflectionHelper::isSubclassOf($request, SaloonRequest::class)) {
+                $result = ! is_null($this->findRequestInHistory($request));
+            } else {
+                $result = ! is_null($this->findRequestWithUrl($request));
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if a request has not been sent.
+     *
+     * @param string|callable $request
+     * @return bool
+     * @throws \ReflectionException
+     */
+    protected function checkRequestWasNotSent(string|callable $request): bool
+    {
+        return ! $this->checkRequestWasSent($request);
+    }
+
+    /**
+     * Assert a given request was sent.
+     *
+     * @param string $request
+     * @return SaloonResponse|null
+     */
+    protected function findRequestInHistory(string $request): ?SaloonResponse
+    {
+        foreach ($this->getRecordedResponses() as $recordedResponse) {
+            if ($recordedResponse->getOriginalRequest() instanceof $request) {
+                return $recordedResponse;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find a request that matches a given url pattern
+     *
+     * @param string $url
+     * @return SaloonResponse|null
+     */
+    protected function findRequestWithUrl(string $url): ?SaloonResponse
+    {
+        foreach ($this->getRecordedResponses() as $recordedResponse) {
+            $request = $recordedResponse->getOriginalRequest();
+
+            if (URLHelper::matches($url, $request->getFullRequestUrl())) {
+                return $recordedResponse;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Clients/BaseMockClient.php
+++ b/src/Clients/BaseMockClient.php
@@ -331,7 +331,7 @@ class BaseMockClient
             if (class_exists($request) && ReflectionHelper::isSubclassOf($request, SaloonRequest::class)) {
                 $result = $this->findResponseByRequest($request) instanceof SaloonResponse;
             } else {
-                $result = $this->findResponseWithRequestUrl($request) instanceof SaloonResponse;
+                $result = $this->findResponseByRequestUrl($request) instanceof SaloonResponse;
             }
         }
 
@@ -357,7 +357,7 @@ class BaseMockClient
      * @param string $request
      * @return SaloonResponse|null
      */
-    protected function findResponseByRequest(string $request): ?SaloonResponse
+    public function findResponseByRequest(string $request): ?SaloonResponse
     {
         $lastRequest = $this->getLastRequest();
 
@@ -381,7 +381,7 @@ class BaseMockClient
      * @return SaloonResponse|null
      * @throws \Sammyjo20\Saloon\Exceptions\SaloonInvalidConnectorException
      */
-    protected function findResponseWithRequestUrl(string $url): ?SaloonResponse
+    public function findResponseByRequestUrl(string $url): ?SaloonResponse
     {
         $lastRequest = $this->getLastRequest();
 

--- a/src/Clients/BaseMockClient.php
+++ b/src/Clients/BaseMockClient.php
@@ -270,7 +270,7 @@ class BaseMockClient
     {
         $this->assertSent($request);
 
-        $response = $this->findRequestInHistory($request);
+        $response = $this->findResponseByRequest($request);
 
         PHPUnit::assertEquals($response->json(), $data, 'Expected request data was not sent.');
     }
@@ -313,9 +313,9 @@ class BaseMockClient
 
         if (is_string($request)) {
             if (class_exists($request) && ReflectionHelper::isSubclassOf($request, SaloonRequest::class)) {
-                $result = ! is_null($this->findRequestInHistory($request));
+                $result = ! is_null($this->findResponseByRequest($request));
             } else {
-                $result = ! is_null($this->findRequestWithUrl($request));
+                $result = ! is_null($this->findResponseWithRequestUrl($request));
             }
         }
 
@@ -340,7 +340,7 @@ class BaseMockClient
      * @param string $request
      * @return SaloonResponse|null
      */
-    protected function findRequestInHistory(string $request): ?SaloonResponse
+    protected function findResponseByRequest(string $request): ?SaloonResponse
     {
         foreach ($this->getRecordedResponses() as $recordedResponse) {
             if ($recordedResponse->getOriginalRequest() instanceof $request) {
@@ -357,7 +357,7 @@ class BaseMockClient
      * @param string $url
      * @return SaloonResponse|null
      */
-    protected function findRequestWithUrl(string $url): ?SaloonResponse
+    protected function findResponseWithRequestUrl(string $url): ?SaloonResponse
     {
         foreach ($this->getRecordedResponses() as $recordedResponse) {
             $request = $recordedResponse->getOriginalRequest();

--- a/src/Clients/BaseMockClient.php
+++ b/src/Clients/BaseMockClient.php
@@ -53,13 +53,6 @@ class BaseMockClient
     protected array $recordedResponses = [];
 
     /**
-     * The last response the mock client saw.
-     *
-     * @var SaloonResponse|null
-     */
-    protected SaloonResponse|null $lastResponse = null;
-
-    /**
      * @param array $mockData
      * @throws SaloonInvalidMockResponseCaptureMethodException
      */
@@ -201,7 +194,6 @@ class BaseMockClient
     public function recordResponse(SaloonResponse $response): void
     {
         $this->recordedResponses[] = $response;
-        $this->lastResponse = $response;
     }
 
     /**
@@ -221,7 +213,7 @@ class BaseMockClient
      */
     public function getLastRequest(): ?SaloonRequest
     {
-        return $this->lastResponse?->getOriginalRequest();
+        return $this->getLastResponse()?->getOriginalRequest();
     }
 
     /**
@@ -231,7 +223,11 @@ class BaseMockClient
      */
     public function getLastResponse(): ?SaloonResponse
     {
-        return $this->lastResponse;
+        $lastResponse = end($this->recordedResponses);
+
+        reset($this->recordedResponses);
+
+        return $lastResponse;
     }
 
     /**

--- a/src/Helpers/URLHelper.php
+++ b/src/Helpers/URLHelper.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sammyjo20\Saloon\Helpers;
+
+use Illuminate\Support\Str;
+
+class URLHelper
+{
+    /**
+     * Check if a URL matches a given pattern
+     *
+     * @param string $pattern
+     * @param string $value
+     * @return bool
+     */
+    public static function matches(string $pattern, string $value): bool
+    {
+        return Str::is(Str::start($pattern, '*'), $value);
+    }
+}

--- a/src/Managers/RequestManager.php
+++ b/src/Managers/RequestManager.php
@@ -201,7 +201,13 @@ class RequestManager
         /** @var SaloonResponse $response */
         $response = new $responseClass($requestOptions, $request, $response, $exception);
 
-        $response->setMocked($this->isMocking());
+        // If we are mocking, we should record the request and response on the mock manager,
+        // so we can run assertions on the responses.
+
+        if ($this->isMocking()) {
+            $response->setMocked(true);
+            $this->mockClient->recordResponse($response);
+        }
 
         if (property_exists($this->connector, 'shouldGuessStatusFromBody') || property_exists($this->request, 'shouldGuessStatusFromBody')) {
             $response->guessesStatusFromBody();

--- a/src/Traits/CollectsConfig.php
+++ b/src/Traits/CollectsConfig.php
@@ -77,12 +77,11 @@ trait CollectsConfig
 
     /**
      * Get all headers or filter with a key.
-     * Todo: Throw an error if it doesn't exist.
      *
      * @param string|null $key
      * @return array
      */
-    public function getConfig(string $key = null): array
+    public function getConfig(string $key = null): mixed
     {
         if ($this->includeDefaultConfig === true) {
             $configBag = array_merge($this->defaultConfig(), $this->customConfig);

--- a/src/Traits/CollectsData.php
+++ b/src/Traits/CollectsData.php
@@ -109,17 +109,6 @@ trait CollectsData
     }
 
     /**
-     * Get an individual data
-     *
-     * @param string $key
-     * @return string
-     */
-    public function getDataByKey(string $key): string
-    {
-        return $this->getData($key);
-    }
-
-    /**
      * Should we ignore the default data when calling `->getData()`?
      *
      * @return $this

--- a/src/Traits/CollectsHeaders.php
+++ b/src/Traits/CollectsHeaders.php
@@ -76,7 +76,6 @@ trait CollectsHeaders
 
     /**
      * Get all headers or filter with a key.
-     * Todo: Throw an error if it doesn't exist.
      *
      * @param string|null $key
      * @return array

--- a/tests/Unit/LaravelManagerTest.php
+++ b/tests/Unit/LaravelManagerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Sammyjo20\Saloon\Clients\MockClient;
+use Sammyjo20\Saloon\Managers\LaravelManager;
+
+test('the manager can have mocking mode turned on', function () {
+    $laravelManager = new LaravelManager();
+
+    $laravelManager->setIsMocking(true);
+
+    expect($laravelManager)->isMocking()->toBeTrue();
+
+    $laravelManager->setIsMocking(false);
+
+    expect($laravelManager)->isMocking()->toBeFalse();
+});
+
+test('the manager can have a mock client assigned to it ', function () {
+    $laravelManager = new LaravelManager();
+    $mockClient = new MockClient();
+
+    $laravelManager->setMockClient($mockClient);
+
+    expect($laravelManager)->getMockClient()->toBe($mockClient);
+});

--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use Sammyjo20\Saloon\Clients\MockClient;
+use Sammyjo20\Saloon\Http\MockResponse;
+use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\Saloon\Http\SaloonResponse;
+use Sammyjo20\Saloon\Tests\Resources\Requests\ErrorRequest;
+use Sammyjo20\Saloon\Tests\Resources\Requests\UserRequest;
+
+test('that assertSent works with a request', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+    ]);
+
+    (new UserRequest())->send($mockClient);
+
+    $mockClient->assertSent(UserRequest::class);
+});
+
+test('that assertSent works with a closure', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200),
+        ErrorRequest::class => new MockResponse(['error' => 'Server Error'], 500),
+    ]);
+
+    $originalRequest = new UserRequest();
+    $originalResponse = $originalRequest->send($mockClient);
+
+    $mockClient->assertSent(function ($request, $response) use ($originalRequest, $originalResponse) {
+        expect($request)->toBeInstanceOf(SaloonRequest::class);
+        expect($response)->toBeInstanceOf(SaloonResponse::class);
+
+        expect($request)->toBe($originalRequest);
+        expect($response)->toBe($originalResponse);
+
+        return true;
+    });
+
+    $newRequest = new ErrorRequest();
+    $newResponse = $newRequest->send($mockClient);
+
+    $mockClient->assertSent(function ($request, $response) use ($newRequest, $newResponse) {
+        expect($request)->toBeInstanceOf(SaloonRequest::class);
+        expect($response)->toBeInstanceOf(SaloonResponse::class);
+
+        expect($request)->toBe($newRequest);
+        expect($response)->toBe($newResponse);
+
+        return true;
+    });
+});
+
+test('that assertSent works with a url', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+    ]);
+
+    (new UserRequest())->send($mockClient);
+
+    $mockClient->assertSent('samcarre.dev/*');
+    $mockClient->assertSent('/user');
+    $mockClient->assertSent('api/user');
+});
+
+test('that assertNotSent works with a request', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200),
+        ErrorRequest::class => new MockResponse(['error' => 'Server Error'], 500),
+    ]);
+
+    (new ErrorRequest())->send($mockClient);
+
+    $mockClient->assertNotSent(UserRequest::class);
+});
+
+test('that assertNotSent works with a closure', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200),
+        ErrorRequest::class => new MockResponse(['error' => 'Server Error'], 500),
+    ]);
+
+    $originalRequest = new ErrorRequest();
+    $originalResponse = $originalRequest->send($mockClient);
+
+    $mockClient->assertNotSent(function ($request) {
+        return $request instanceof UserRequest;
+    });
+});
+
+test('that assertNotSent works with a url', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+    ]);
+
+    (new UserRequest())->send($mockClient);
+
+    $mockClient->assertNotSent('google.com/*');
+    $mockClient->assertNotSent('/error');
+});
+
+test('that assertSentJson works properly', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+    ]);
+
+    (new UserRequest())->send($mockClient);
+
+    $mockClient->assertSentJson(UserRequest::class, [
+        'name' => 'Sam'
+    ]);
+});
+
+test('test assertNothingSent works properly', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+    ]);
+
+    $mockClient->assertNothingSent();
+});
+
+test('test assertSentCount works properly', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sam'], 200),
+        new MockResponse(['name' => 'Taylor'], 200),
+        new MockResponse(['name' => 'Marcel'], 200),
+    ]);
+
+    (new UserRequest())->send($mockClient);
+    (new UserRequest())->send($mockClient);
+    (new UserRequest())->send($mockClient);
+
+    $mockClient->assertSentCount(3);
+});

--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -1,15 +1,15 @@
 <?php
 
-use Sammyjo20\Saloon\Clients\MockClient;
 use Sammyjo20\Saloon\Http\MockResponse;
+use Sammyjo20\Saloon\Clients\MockClient;
 use Sammyjo20\Saloon\Http\SaloonRequest;
 use Sammyjo20\Saloon\Http\SaloonResponse;
-use Sammyjo20\Saloon\Tests\Resources\Requests\ErrorRequest;
 use Sammyjo20\Saloon\Tests\Resources\Requests\UserRequest;
+use Sammyjo20\Saloon\Tests\Resources\Requests\ErrorRequest;
 
 test('that assertSent works with a request', function () {
     $mockClient = new MockClient([
-        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200),
     ]);
 
     (new UserRequest())->send($mockClient);
@@ -52,7 +52,7 @@ test('that assertSent works with a closure', function () {
 
 test('that assertSent works with a url', function () {
     $mockClient = new MockClient([
-        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200),
     ]);
 
     (new UserRequest())->send($mockClient);
@@ -89,7 +89,7 @@ test('that assertNotSent works with a closure', function () {
 
 test('that assertNotSent works with a url', function () {
     $mockClient = new MockClient([
-        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200),
     ]);
 
     (new UserRequest())->send($mockClient);
@@ -100,19 +100,19 @@ test('that assertNotSent works with a url', function () {
 
 test('that assertSentJson works properly', function () {
     $mockClient = new MockClient([
-        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200),
     ]);
 
     (new UserRequest())->send($mockClient);
 
     $mockClient->assertSentJson(UserRequest::class, [
-        'name' => 'Sam'
+        'name' => 'Sam',
     ]);
 });
 
 test('test assertNothingSent works properly', function () {
     $mockClient = new MockClient([
-        UserRequest::class => new MockResponse(['name' => 'Sam'], 200)
+        UserRequest::class => new MockResponse(['name' => 'Sam'], 200),
     ]);
 
     $mockClient->assertNothingSent();

--- a/tests/Unit/MockClientTest.php
+++ b/tests/Unit/MockClientTest.php
@@ -133,7 +133,7 @@ test('you can get an array of the recorded requests', function () {
     expect($responses)->toEqual([
         $responseA,
         $responseB,
-        $responseC
+        $responseC,
     ]);
 });
 

--- a/tests/Unit/MockClientTest.php
+++ b/tests/Unit/MockClientTest.php
@@ -168,3 +168,43 @@ test('if there are no recorded responses the getLastRequest will return null', f
 
     expect($mockClient)->getLastRequest()->toBeNull();
 });
+
+test('if the response is not the last response it will use the loop to find it', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sam'], 200),
+        new MockResponse(['error' => 'Server Error'], 500),
+    ]);
+
+    $responseA = (new ErrorRequest())->send($mockClient);
+    $responseB = (new UserRequest())->send($mockClient);
+
+    expect($mockClient)->getLastResponse()->toBe($responseB);
+
+    // Uses last response
+
+    expect($mockClient)->findResponseByRequest(UserRequest::class)->toBe($responseB);
+
+    // Does not use the last response
+
+    expect($mockClient)->findResponseByRequest(ErrorRequest::class)->toBe($responseA);
+});
+
+test('it will find the response by url if it is not the last response', function () {
+    $mockClient = new MockClient([
+        '/user' => new MockResponse(['name' => 'Sam'], 200),
+        '/error' => new MockResponse(['error' => 'Server Error'], 500),
+    ]);
+
+    $responseA = (new ErrorRequest())->send($mockClient);
+    $responseB = (new UserRequest())->send($mockClient);
+
+    expect($mockClient)->getLastResponse()->toBe($responseB);
+
+    // Uses last response
+
+    expect($mockClient)->findResponseByRequestUrl('/user')->toBe($responseB);
+
+    // Does not use the last response
+
+    expect($mockClient)->findResponseByRequestUrl('/error')->toBe($responseA);
+});

--- a/tests/Unit/MockClientTest.php
+++ b/tests/Unit/MockClientTest.php
@@ -116,3 +116,39 @@ test('saloon throws an exception if it cant work out the url response', function
 
     expect($mockClient->guessNextResponse($requestC))->toEqual($responseC);
 });
+
+test('you can get an array of the recorded requests', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sam'], 200),
+        new MockResponse(['name' => 'Taylor'], 200),
+        new MockResponse(['name' => 'Marcel'], 200),
+    ]);
+
+    $responseA = (new UserRequest())->send($mockClient);
+    $responseB = (new UserRequest())->send($mockClient);
+    $responseC = (new UserRequest())->send($mockClient);
+
+    $responses = $mockClient->getRecordedResponses();
+
+    expect($responses)->toEqual([
+        $responseA,
+        $responseB,
+        $responseC
+    ]);
+});
+
+test('you can get the last recorded request', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sam'], 200),
+        new MockResponse(['name' => 'Taylor'], 200),
+        new MockResponse(['name' => 'Marcel'], 200),
+    ]);
+
+    $responseA = (new UserRequest())->send($mockClient);
+    $responseB = (new UserRequest())->send($mockClient);
+    $responseC = (new UserRequest())->send($mockClient);
+
+    $lastResponse = $mockClient->getLastResponse();
+
+    expect($lastResponse)->toBe($responseC);
+});

--- a/tests/Unit/MockClientTest.php
+++ b/tests/Unit/MockClientTest.php
@@ -152,3 +152,19 @@ test('you can get the last recorded request', function () {
 
     expect($lastResponse)->toBe($responseC);
 });
+
+test('if there are no recorded responses the getLastResponse will return null', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sam'], 200),
+    ]);
+
+    expect($mockClient)->getLastResponse()->toBeNull();
+});
+
+test('if there are no recorded responses the getLastRequest will return null', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sam'], 200),
+    ]);
+
+    expect($mockClient)->getLastRequest()->toBeNull();
+});


### PR DESCRIPTION
The following expectation methods have been added.

- AssertSent (accepts request classes, closures and URL patterns)
- AssertNotSent (inverse of assert sent)
- AssertSentJson (accepts a class and an array to check both are equal)
- AssertNothingSent
- AssertSentCount

Here's how you can use it

```php
// Laravel (using Facade)

Saloon::assertSent(GetForgeServerRequest::class);

// Normal PHP

$mockClient->assertSent(GetForgeServerRequest::class);
```