### PR TITLE
Update HasFormParams.php

### DIFF
--- a/src/Traits/Features/HasFormParams.php
+++ b/src/Traits/Features/HasFormParams.php
@@ -4,7 +4,7 @@ namespace Sammyjo20\Saloon\Traits\Features;
 
 trait HasFormParams
 {
-    public function bootHasBodyFeature()
+    public function bootHasFormParamsFeature()
     {
         $this->addConfig('form_params', $this->getData());
     }


### PR DESCRIPTION
bootHasBodyFeature was never called when using this trait since its not folowing the correct naming convention.

This change solved that issue and the data is attached correctly.