### PR TITLE
Mocking exceptions

### DIFF
--- a/src/Data/MockExceptionClosure.php
+++ b/src/Data/MockExceptionClosure.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sammyjo20\Saloon\Data;
+
+use Psr\Http\Message\RequestInterface;
+use Throwable;
+
+class MockExceptionClosure
+{
+    /**
+     * @param mixed $closure
+     */
+    public function __construct(
+        public mixed $closure
+    )
+    {
+        //
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return Throwable
+     */
+    public function call(RequestInterface $request): Throwable
+    {
+        return call_user_func($this->closure, $request);
+    }
+}

--- a/src/Http/Middleware/MockMiddleware.php
+++ b/src/Http/Middleware/MockMiddleware.php
@@ -2,6 +2,9 @@
 
 namespace Sammyjo20\Saloon\Http\Middleware;
 
+use GuzzleHttp\Promise\RejectedPromise;
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\RequestInterface;
 use Sammyjo20\Saloon\Http\MockResponse;
 use GuzzleHttp\Promise\FulfilledPromise;
 
@@ -28,8 +31,12 @@ class MockMiddleware
      */
     public function __invoke(callable $handler)
     {
-        return function () {
-            return new FulfilledPromise($this->mockResponse->toGuzzleResponse());
-        };
+        $mockResponse = $this->mockResponse;
+
+        if ($mockResponse->throwsException()) {
+            return fn (RequestInterface $request) => new RejectedPromise($mockResponse->getException($request));
+        }
+
+        return fn () => new FulfilledPromise($this->mockResponse->toGuzzleResponse());
     }
 }


### PR DESCRIPTION
Introduces the ability to mock exceptions, including Guzzle exceptions, like ConnectException.

For example:

```php
$mockClient = new MockClient([
    MockResponse::make(['name' => 'Sam'])->throw(new Exception('Custom Exception!')),
]);

// Or using Guzzle

$mockClient = new MockClient([
    MockResponse::make(['name' => 'Sam'])->throw(fn ($guzzleRequest) => new GuzzleException('Cannot connect!', $guzzleRequest)),
]);
```