### PR TITLE
Feature | Asynchronous requests

### DIFF
--- a/src/Http/SaloonConnector.php
+++ b/src/Http/SaloonConnector.php
@@ -2,6 +2,7 @@
 
 namespace Sammyjo20\Saloon\Http;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
@@ -158,6 +159,21 @@ abstract class SaloonConnector implements SaloonConnectorInterface
     public function send(SaloonRequest $request, MockClient $mockClient = null): SaloonResponse
     {
         return $this->request($request)->send($mockClient);
+    }
+
+    /**
+     * Send an asynchronous Saloon request with the current instance of the connector.
+     *
+     * @param SaloonRequest $request
+     * @param MockClient|null $mockClient
+     * @return PromiseInterface
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \ReflectionException
+     * @throws \Sammyjo20\Saloon\Exceptions\SaloonException
+     */
+    public function sendAsync(SaloonRequest $request, MockClient $mockClient = null): PromiseInterface
+    {
+        return $this->request($request)->sendAsync($mockClient);
     }
 
     /**

--- a/src/Managers/RequestManager.php
+++ b/src/Managers/RequestManager.php
@@ -176,7 +176,7 @@ class RequestManager
      * @throws \Sammyjo20\Saloon\Exceptions\SaloonInvalidHandlerException
      * @throws \Sammyjo20\Saloon\Exceptions\SaloonMissingMockException
      */
-    public function send(): SaloonResponse|PromiseInterface
+    public function send()
     {
         // Let's firstly hydrate the request manager, which will retrieve all the attributes
         // from the request and connector and build them up inside the request.

--- a/src/Managers/RequestManager.php
+++ b/src/Managers/RequestManager.php
@@ -165,7 +165,7 @@ class RequestManager
     }
 
     /**
-     * Send of the request 🚀
+     * Send off the request 🚀
      *
      * @return SaloonResponse|PromiseInterface
      * @throws SaloonInvalidResponseClassException

--- a/src/Traits/SendsRequests.php
+++ b/src/Traits/SendsRequests.php
@@ -2,38 +2,56 @@
 
 namespace Sammyjo20\Saloon\Traits;
 
+use GuzzleHttp\Promise\PromiseInterface;
 use Sammyjo20\Saloon\Clients\MockClient;
+use Sammyjo20\Saloon\Exceptions\SaloonException;
 use Sammyjo20\Saloon\Http\SaloonResponse;
 use Sammyjo20\Saloon\Managers\RequestManager;
 
 trait SendsRequests
 {
     /**
-     * Send the request.
+     * Send the request synchronously.
      *
      * @param MockClient|null $mockClient
+     * @param bool $asynchronous
      * @return SaloonResponse
+     * @throws SaloonException
+     * @throws \GuzzleHttp\Exception\GuzzleException
+     * @throws \ReflectionException
+     */
+    public function send(MockClient $mockClient = null, bool $asynchronous = false): SaloonResponse
+    {
+        // 🚀 ... 🌑 ... 💫
+
+        return $this->getRequestManager($mockClient, $asynchronous)->send();
+    }
+
+    /**
+     * Send the request asynchronously
+     *
+     * @param MockClient|null $mockClient
+     * @return PromiseInterface
+     * @throws SaloonException
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \ReflectionException
      * @throws \Sammyjo20\Saloon\Exceptions\SaloonException
      */
-    public function send(MockClient $mockClient = null): SaloonResponse
+    public function sendAsync(MockClient $mockClient = null): PromiseInterface
     {
-        // 🚀 ... 🌑 ... 💫
-
-        return $this->getRequestManager($mockClient)->send();
+        return $this->getRequestManager($mockClient, true)->send();
     }
 
     /**
      * Create a request manager instance from the request.
      *
      * @param MockClient|null $mockClient
+     * @param bool $asynchronous
      * @return RequestManager
-     * @throws \Sammyjo20\Saloon\Exceptions\SaloonInvalidConnectorException
-     * @throws \Sammyjo20\Saloon\Exceptions\SaloonMultipleMockMethodsException
+     * @throws \Sammyjo20\Saloon\Exceptions\SaloonException
      */
-    public function getRequestManager(MockClient $mockClient = null): RequestManager
+    public function getRequestManager(MockClient $mockClient = null, bool $asynchronous = false): RequestManager
     {
-        return new RequestManager($this, $mockClient);
+        return new RequestManager($this, $mockClient, $asynchronous);
     }
 }

--- a/tests/Feature/AsyncRequestTest.php
+++ b/tests/Feature/AsyncRequestTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use GuzzleHttp\Promise\Promise;
+use Sammyjo20\Saloon\Clients\MockClient;
+use Sammyjo20\Saloon\Exceptions\SaloonRequestException;
+use Sammyjo20\Saloon\Http\MockResponse;
+use Sammyjo20\Saloon\Http\SaloonResponse;
+use Sammyjo20\Saloon\Tests\Fixtures\Requests\ErrorRequest;
+use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
+use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequestWithCustomResponse;
+use Sammyjo20\Saloon\Tests\Fixtures\Responses\UserData;
+use Sammyjo20\Saloon\Tests\Fixtures\Responses\UserResponse;
+
+test('an asynchronous request can be made successfully', function () {
+    $request = new UserRequest();
+    $promise = $request->sendAsync();
+
+    expect($promise)->toBeInstanceOf(Promise::class);
+
+    $response = $promise->wait();
+
+    expect($response)->toBeInstanceOf(SaloonResponse::class);
+
+    $data = $response->json();
+
+    expect($response->isMocked())->toBeFalse();
+    expect($response->status())->toEqual(200);
+
+    expect($data)->toEqual([
+        'name' => 'Sammyjo20',
+        'actual_name' => 'Sam',
+        'twitter' => '@carre_sam',
+    ]);
+});
+
+test('an asynchronous request will return a custom response', function () {
+    $mockClient = new MockClient([MockResponse::make(['foo' => 'bar'], 200)]);
+    $request = new UserRequestWithCustomResponse();
+
+    $promise = $request->sendAsync($mockClient);
+    $response = $promise->wait();
+
+    expect($response)->toBeInstanceOf(UserResponse::class);
+    expect($response)->customCastMethod()->toBeInstanceOf(UserData::class);
+    expect($response)->foo()->toBe('bar');
+});
+
+test('an asynchronous request can handle an exception properly', function () {
+    $request = new ErrorRequest();
+    $promise = $request->sendAsync();
+
+    $this->expectException(SaloonRequestException::class);
+
+    $promise->wait();
+});

--- a/tests/Unit/AsyncRequestTest.php
+++ b/tests/Unit/AsyncRequestTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\Promise;
+use Sammyjo20\Saloon\Clients\MockClient;
+use Sammyjo20\Saloon\Exceptions\SaloonException;
+use Sammyjo20\Saloon\Exceptions\SaloonRequestException;
+use Sammyjo20\Saloon\Http\MockResponse;
+use Sammyjo20\Saloon\Http\SaloonResponse;
+use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
+
+test('an asynchronous request will return a saloon response on a successful request', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam'])
+    ]);
+
+    $request = new UserRequest;
+    $promise = $request->sendAsync($mockClient);
+
+    expect($promise)->toBeInstanceOf(Promise::class);
+
+    $response = $promise->wait();
+
+    expect($response)->toBeInstanceOf(SaloonResponse::class);
+    expect($response->json())->toEqual(['name' => 'Sam']);
+    expect($response->status())->toEqual(200);
+});
+
+test('an asynchronous request will throw a saloon exception on an unsuccessful request', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['error' => 'Server Error'], 500)
+    ]);
+
+    $request = new UserRequest;
+    $promise = $request->sendAsync($mockClient);
+
+    expect($promise)->toBeInstanceOf(Promise::class);
+
+    try {
+        $promise->wait();
+    } catch (Exception $exception) {
+        expect($exception)->toBeInstanceOf(SaloonRequestException::class);
+
+        $response = $exception->getSaloonResponse();
+
+        expect($response)->toBeInstanceOf(SaloonResponse::class);
+        expect($response->json())->toEqual(['error' => 'Server Error']);
+        expect($response->status())->toEqual(500);
+        expect($response->getGuzzleException())->toBeInstanceOf(RequestException::class);
+    }
+});
+
+test('an asynchronous request will return a connect exception if a connection error happens', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Patrick'])->throw(fn ($guzzleRequest) => new ConnectException('Unable to connect!', $guzzleRequest)),
+    ]);
+
+    $request = new UserRequest;
+    $promise = $request->sendAsync($mockClient);
+
+    try {
+        $promise->wait();
+    } catch (Exception $exception) {
+        expect($exception)->toBeInstanceOf(ConnectException::class);
+        expect($exception->getMessage())->toEqual('Unable to connect!');
+    }
+});
+
+test('if you chain an asynchronous request you can have a SaloonResponse', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam'])
+    ]);
+
+    $request = new UserRequest;
+    $promise = $request->sendAsync($mockClient);
+
+    $promise->then(
+        function (SaloonResponse $response) {
+            expect($response)->toBeInstanceOf(SaloonResponse::class);
+        }
+    );
+
+    $promise->wait();
+});
+
+test('if you chain an erroneous asynchronous request the error can be caught in the rejection handler', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['error' => 'Server Error'], 500)
+    ]);
+
+    $request = new UserRequest;
+    $promise = $request->sendAsync($mockClient);
+
+    $promise->then(
+        null,
+        function (SaloonRequestException $exception) {
+            $response = $exception->getSaloonResponse();
+
+            expect($response)->toBeInstanceOf(SaloonResponse::class);
+            expect($response->status())->toEqual(500);
+            expect($response->getGuzzleException())->toBeInstanceOf(RequestException::class);
+        }
+    );
+
+    try {
+        $promise->wait();
+    } catch (\Exception $ex) {
+        //
+    }
+});
+
+test('if a connection exception happens it will be provided in the rejection handler', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Patrick'])->throw(fn ($guzzleRequest) => new ConnectException('Unable to connect!', $guzzleRequest)),
+    ]);
+
+    $request = new UserRequest;
+    $promise = $request->sendAsync($mockClient);
+
+    $promise->then(
+        null,
+        function (ConnectException $exception) {
+            expect($exception->getMessage())->toEqual('Unable to connect!');
+        }
+    );
+
+    try {
+        $promise->wait();
+    } catch (\Exception $ex) {
+        //
+    }
+});

--- a/tests/Unit/ConnectorTest.php
+++ b/tests/Unit/ConnectorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use GuzzleHttp\Promise\Promise;
 use Sammyjo20\Saloon\Http\MockResponse;
 use Sammyjo20\Saloon\Clients\MockClient;
 use Sammyjo20\Saloon\Http\SaloonRequest;
@@ -36,6 +37,22 @@ test('you can send a request through the connector', function () {
 
     $connector = new TestConnector();
     $response = $connector->send(new UserRequest, $mockClient);
+
+    expect($response)->toBeInstanceOf(SaloonResponse::class);
+    expect($response->json())->toEqual(['name' => 'Sammyjo20', 'actual_name' => 'Sam Carré', 'twitter' => '@carre_sam']);
+});
+
+test('you can send an asynchronous request through the connector', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sammyjo20', 'actual_name' => 'Sam Carré', 'twitter' => '@carre_sam']),
+    ]);
+
+    $connector = new TestConnector();
+    $promise = $connector->sendAsync(new UserRequest, $mockClient);
+
+    expect($promise)->toBeInstanceOf(Promise::class);
+
+    $response = $promise->wait();
 
     expect($response)->toBeInstanceOf(SaloonResponse::class);
     expect($response->json())->toEqual(['name' => 'Sammyjo20', 'actual_name' => 'Sam Carré', 'twitter' => '@carre_sam']);


### PR DESCRIPTION
Introducing support for Guzzle's asynchronous requests in Saloon! 🎉

This PR introduces a new `sendAsync` method on the request/connector that you can use to return a [Guzzle Promise](https://github.com/guzzle/promises).

```php
$request = new GetUserRequest(userId: 1);
$promise = $request->sendAsync();

$promise->then(
    function (SaloonResponse $response) {
        // Handle successful response...
    },
    function (SaloonRequestException $exception) {
        $response = $exception->getSaloonResponse();

        // Handle unsuccessful response...
    },
)
```

### Important Note
Typically, Saloon will return a response with the error inside of the response, however with promises, if an error occurs - Saloon will return the response in the rejection chain instead. Should this be the case? Or should we only reserve rejection for exceptions like ConnectException and always return responses, even if errored in the resolve callback?