### PR TITLE
Feature | Nested SDK Requests

### DIFF
--- a/src/Exceptions/InvalidRequestKeyException.php
+++ b/src/Exceptions/InvalidRequestKeyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sammyjo20\Saloon\Exceptions;
+
+class InvalidRequestKeyException extends SaloonException
+{
+    //
+}

--- a/src/Exceptions/InvalidRequestTypeException.php
+++ b/src/Exceptions/InvalidRequestTypeException.php
@@ -4,5 +4,4 @@ namespace Sammyjo20\Saloon\Exceptions;
 
 class InvalidRequestTypeException extends SaloonException
 {
-
 }

--- a/src/Exceptions/InvalidRequestTypeException.php
+++ b/src/Exceptions/InvalidRequestTypeException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Sammyjo20\Saloon\Exceptions;
-
-class InvalidRequestTypeException extends SaloonException
-{
-}

--- a/src/Exceptions/InvalidRequestTypeException.php
+++ b/src/Exceptions/InvalidRequestTypeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Sammyjo20\Saloon\Exceptions;
+
+class InvalidRequestTypeException extends SaloonException
+{
+
+}

--- a/src/Exceptions/NestedRequestNotFoundException.php
+++ b/src/Exceptions/NestedRequestNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sammyjo20\Saloon\Exceptions;
+
+use Sammyjo20\Saloon\Http\SaloonConnector;
+
+class NestedRequestNotFoundException extends SaloonException
+{
+    public function __construct(string $method, string $collectionName, SaloonConnector $connector)
+    {
+        parent::__construct(sprintf('Unable to find the "%s" request method in the "%s" collection on the "%s" connector.', $method, $collectionName, get_class($connector)));
+    }
+}

--- a/src/Helpers/ProxyRequestNameHelper.php
+++ b/src/Helpers/ProxyRequestNameHelper.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sammyjo20\Saloon\Helpers;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use ReflectionClass;
+
+class ProxyRequestNameHelper
+{
+    /**
+     * Recursively generate the names of requests.
+     *
+     * @param array $requests
+     * @return array
+     * @throws \ReflectionException
+     */
+    public static function generateNames(array $requests): array
+    {
+        return (new Collection($requests))->mapWithKeys(function ($value, $key) {
+            if (is_array($value)) {
+                $value = static::generateNames($value);
+            }
+
+            if (is_string($key)) {
+                return [$key => $value];
+            }
+
+            $guessedKey = Str::camel((new ReflectionClass($value))->getShortName());
+
+            return [$guessedKey => $value];
+        })->toArray();
+    }
+}

--- a/src/Helpers/ProxyRequestNameHelper.php
+++ b/src/Helpers/ProxyRequestNameHelper.php
@@ -2,9 +2,9 @@
 
 namespace Sammyjo20\Saloon\Helpers;
 
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use ReflectionClass;
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
 
 class ProxyRequestNameHelper
 {

--- a/src/Helpers/ProxyRequestNameHelper.php
+++ b/src/Helpers/ProxyRequestNameHelper.php
@@ -5,6 +5,7 @@ namespace Sammyjo20\Saloon\Helpers;
 use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
+use Sammyjo20\Saloon\Exceptions\InvalidRequestKeyException;
 
 class ProxyRequestNameHelper
 {
@@ -24,6 +25,10 @@ class ProxyRequestNameHelper
 
             if (is_string($key)) {
                 return [$key => $value];
+            }
+
+            if (is_array($value)) {
+                throw new InvalidRequestKeyException('Request groups must be keyed.');
             }
 
             $guessedKey = Str::camel((new ReflectionClass($value))->getShortName());

--- a/src/Helpers/RequestHelper.php
+++ b/src/Helpers/RequestHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sammyjo20\Saloon\Helpers;
+
+use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\Saloon\Http\SaloonConnector;
+use Sammyjo20\Saloon\Exceptions\SaloonInvalidRequestException;
+
+class RequestHelper
+{
+    /**
+     * Call a request from a connector.
+     *
+     * @param SaloonConnector $connector
+     * @param string $request
+     * @param array $arguments
+     * @return mixed
+     * @throws SaloonInvalidRequestException
+     * @throws \ReflectionException
+     */
+    public static function callFromConnector(SaloonConnector $connector, string $request, array $arguments = [])
+    {
+        $isValidRequest = ReflectionHelper::isSubclassOf($request, SaloonRequest::class);
+
+        if (! $isValidRequest) {
+            throw new SaloonInvalidRequestException($request);
+        }
+
+        return (new $request(...$arguments))->setConnector($connector);
+    }
+}

--- a/src/Http/AnonymousRequestCollection.php
+++ b/src/Http/AnonymousRequestCollection.php
@@ -2,6 +2,7 @@
 
 namespace Sammyjo20\Saloon\Http;
 
+use Sammyjo20\Saloon\Helpers\RequestHelper;
 use Sammyjo20\Saloon\Exceptions\NestedRequestNotFoundException;
 
 class AnonymousRequestCollection extends RequestCollection
@@ -15,19 +16,19 @@ class AnonymousRequestCollection extends RequestCollection
         SaloonConnector $connector,
         protected string $collectionName,
         protected array $requests,
-    )
-    {
+    ) {
         parent::__construct($connector);
     }
 
 
     /**
+     * Call a request on a connector.
+     *
      * @param string $name
      * @param array $arguments
-     * @return SaloonRequest
+     * @return mixed
      * @throws NestedRequestNotFoundException
      * @throws \ReflectionException
-     * @throws \Sammyjo20\Saloon\Exceptions\ClassNotFoundException
      * @throws \Sammyjo20\Saloon\Exceptions\SaloonInvalidRequestException
      */
     public function __call(string $name, array $arguments)
@@ -36,6 +37,6 @@ class AnonymousRequestCollection extends RequestCollection
             throw new NestedRequestNotFoundException($name, $this->collectionName, $this->connector);
         }
 
-        return $this->connector->forwardCallToRequest($this->requests[$name], $arguments);
+        return RequestHelper::callFromConnector($this->connector, $this->requests[$name], $arguments);
     }
 }

--- a/src/Http/AnonymousRequestCollection.php
+++ b/src/Http/AnonymousRequestCollection.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Sammyjo20\Saloon\Http;
+
+use Sammyjo20\Saloon\Exceptions\NestedRequestNotFoundException;
+
+class AnonymousRequestCollection extends RequestCollection
+{
+    /**
+     * @param SaloonConnector $connector
+     * @param string $collectionName
+     * @param array $requests
+     */
+    public function __construct(
+        SaloonConnector $connector,
+        protected string $collectionName,
+        protected array $requests,
+    )
+    {
+        parent::__construct($connector);
+    }
+
+
+    /**
+     * @param string $name
+     * @param array $arguments
+     * @return SaloonRequest
+     * @throws NestedRequestNotFoundException
+     * @throws \ReflectionException
+     * @throws \Sammyjo20\Saloon\Exceptions\ClassNotFoundException
+     * @throws \Sammyjo20\Saloon\Exceptions\SaloonInvalidRequestException
+     */
+    public function __call(string $name, array $arguments)
+    {
+        if (! array_key_exists($name, $this->requests)) {
+            throw new NestedRequestNotFoundException($name, $this->collectionName, $this->connector);
+        }
+
+        return $this->connector->forwardCallToRequest($this->requests[$name], $arguments);
+    }
+}

--- a/src/Http/RequestCollection.php
+++ b/src/Http/RequestCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sammyjo20\Saloon\Http;
+
+abstract class RequestCollection
+{
+    /**
+     * @var SaloonConnector
+     */
+    protected SaloonConnector $connector;
+
+    /**
+     * @param SaloonConnector $connector
+     */
+    public function __construct(SaloonConnector $connector)
+    {
+        $this->connector = $connector;
+    }
+}

--- a/src/Http/SaloonConnector.php
+++ b/src/Http/SaloonConnector.php
@@ -6,6 +6,8 @@ use ReflectionClass;
 use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Sammyjo20\Saloon\Clients\MockClient;
+use Sammyjo20\Saloon\Exceptions\InvalidRequestTypeException;
+use Sammyjo20\Saloon\Helpers\ProxyRequestNameHelper;
 use Sammyjo20\Saloon\Traits\CollectsData;
 use Sammyjo20\Saloon\Traits\CollectsConfig;
 use Sammyjo20\Saloon\Traits\CollectsHeaders;
@@ -79,12 +81,8 @@ abstract class SaloonConnector implements SaloonConnectorInterface
      * @throws SaloonInvalidRequestException
      * @throws \ReflectionException
      */
-    protected function forwardCallToRequest(string $request, array $args = []): SaloonRequest
+    public function forwardCallToRequest(string $request, array $args = []): SaloonRequest
     {
-        if (! class_exists($request)) {
-            throw new ClassNotFoundException($request);
-        }
-
         $isValidRequest = ReflectionHelper::isSubclassOf($request, SaloonRequest::class);
 
         if (! $isValidRequest) {
@@ -110,19 +108,9 @@ abstract class SaloonConnector implements SaloonConnectorInterface
             return $this->registeredRequests;
         }
 
-        $requests = (new Collection($this->requests))->mapWithKeys(function ($value, $key) {
-            if (is_string($key)) {
-                return [$key => $value];
-            }
+        $this->registeredRequests = ProxyRequestNameHelper::generateNames($this->requests);
 
-            $guessedKey = Str::camel((new ReflectionClass($value))->getShortName());
-
-            return [$guessedKey => $value];
-        })->toArray();
-
-        $this->registeredRequests = $requests;
-
-        return $requests;
+        return $this->registeredRequests;
     }
 
     /**
@@ -165,21 +153,15 @@ abstract class SaloonConnector implements SaloonConnectorInterface
      *
      * @param $method
      * @param $arguments
-     * @return SaloonRequest
+     * @return AnonymousRequestCollection|SaloonRequest
      * @throws ClassNotFoundException
-     * @throws SaloonInvalidRequestException
      * @throws SaloonConnectorMethodNotFoundException
+     * @throws SaloonInvalidRequestException
      * @throws \ReflectionException
      */
     public function __call($method, $arguments)
     {
-        if ($this->requestExists($method) === false) {
-            throw new SaloonConnectorMethodNotFoundException($method, $this);
-        }
-
-        $requests = $this->getRegisteredRequests();
-
-        return $this->forwardCallToRequest($requests[$method], $arguments);
+        return $this->guessRequest($method, $arguments);
     }
 
     /**
@@ -195,14 +177,52 @@ abstract class SaloonConnector implements SaloonConnectorInterface
      */
     public static function __callStatic($method, $arguments)
     {
-        $connector = new static;
+        return (new static)->guessRequest($method, $arguments);
+    }
 
-        if ($connector->requestExists($method) === false) {
-            throw new SaloonConnectorMethodNotFoundException($method, $connector);
+    /**
+     * Attempt to guess the next request.
+     *
+     * @param $method
+     * @param $arguments
+     * @return mixed
+     * @throws ClassNotFoundException
+     * @throws SaloonConnectorMethodNotFoundException
+     * @throws SaloonInvalidRequestException
+     * @throws \ReflectionException
+     */
+    protected function guessRequest($method, $arguments): mixed
+    {
+        if ($this->requestExists($method) === false) {
+            throw new SaloonConnectorMethodNotFoundException($method, $this);
         }
 
-        $requests = $connector->getRegisteredRequests();
+        $requests = $this->getRegisteredRequests();
 
-        return $connector->forwardCallToRequest($requests[$method], $arguments);
+        // Work out what it is. If it is an array, pass the array into AnonymousRequestCollection($requests)
+        // If it is a request, just forward the call to the request.
+
+        $resource = $requests[$method];
+
+        // If the request is a type of array, then it must be an anonymous request collection.
+
+        if (is_array($resource)) {
+            return new AnonymousRequestCollection($this, $method, $resource);
+        }
+
+        // Otherwise, check if it is a RequestCollection. If it is, then
+        // return that class - otherwise, just forward the request.
+
+        if (! class_exists($resource)) {
+            throw new ClassNotFoundException($resource);
+        }
+
+        if (ReflectionHelper::isSubclassOf($resource, RequestCollection::class)) {
+            return new $resource($this);
+        }
+
+        // It's just a request, so forward to that.
+
+        return $this->forwardCallToRequest($resource, $arguments);
     }
 }

--- a/src/Http/SaloonConnector.php
+++ b/src/Http/SaloonConnector.php
@@ -2,13 +2,10 @@
 
 namespace Sammyjo20\Saloon\Http;
 
-use ReflectionClass;
-use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 use Sammyjo20\Saloon\Clients\MockClient;
-use Sammyjo20\Saloon\Exceptions\InvalidRequestTypeException;
-use Sammyjo20\Saloon\Helpers\ProxyRequestNameHelper;
 use Sammyjo20\Saloon\Traits\CollectsData;
+use Sammyjo20\Saloon\Helpers\RequestHelper;
 use Sammyjo20\Saloon\Traits\CollectsConfig;
 use Sammyjo20\Saloon\Traits\CollectsHeaders;
 use Sammyjo20\Saloon\Traits\CollectsHandlers;
@@ -17,6 +14,7 @@ use Sammyjo20\Saloon\Traits\HasCustomResponses;
 use Sammyjo20\Saloon\Traits\CollectsQueryParams;
 use Sammyjo20\Saloon\Traits\CollectsInterceptors;
 use Sammyjo20\Saloon\Traits\AuthenticatesRequests;
+use Sammyjo20\Saloon\Helpers\ProxyRequestNameHelper;
 use Sammyjo20\Saloon\Exceptions\ClassNotFoundException;
 use Sammyjo20\Saloon\Interfaces\SaloonConnectorInterface;
 use Sammyjo20\Saloon\Exceptions\SaloonInvalidRequestException;
@@ -77,19 +75,12 @@ abstract class SaloonConnector implements SaloonConnectorInterface
      * @param string $request
      * @param array $args
      * @return SaloonRequest
-     * @throws ClassNotFoundException
      * @throws SaloonInvalidRequestException
      * @throws \ReflectionException
      */
-    public function forwardCallToRequest(string $request, array $args = []): SaloonRequest
+    protected function forwardCallToRequest(string $request, array $args = []): SaloonRequest
     {
-        $isValidRequest = ReflectionHelper::isSubclassOf($request, SaloonRequest::class);
-
-        if (! $isValidRequest) {
-            throw new SaloonInvalidRequestException($request);
-        }
-
-        return (new $request(...$args))->setConnector($this);
+        return RequestHelper::callFromConnector($this, $request, $args);
     }
 
     /**

--- a/tests/Feature/ConnectorRequestTest.php
+++ b/tests/Feature/ConnectorRequestTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use Sammyjo20\Saloon\Exceptions\ClassNotFoundException;
+use Sammyjo20\Saloon\Http\AnonymousRequestCollection;
+use Sammyjo20\Saloon\Tests\Fixtures\Collections\UserCollection;
+use Sammyjo20\Saloon\Tests\Fixtures\Connectors\ServiceRequestConnector;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use Sammyjo20\Saloon\Exceptions\SaloonInvalidRequestException;
@@ -96,4 +99,21 @@ test('it throws an exception if one of the provided request classes is not a sal
     $this->expectException(SaloonInvalidRequestException::class);
 
     $connector->test_connector();
+});
+
+test('a connector request can be defined in an array', function () {
+    $connector = new ServiceRequestConnector;
+    $request = $connector->user();
+
+    expect($request)->toBeInstanceOf(AnonymousRequestCollection::class);
+    expect($request->get())->toBeInstanceOf(UserRequest::class);
+    expect($request->get(1)->userId)->toEqual(1);
+});
+
+test('a connector request collection can be defined', function () {
+    $connector = new ServiceRequestConnector;
+    $request = $connector->custom();
+
+    expect($request)->toBeInstanceOf(UserCollection::class);
+    expect($request->test())->toBeTrue();
 });

--- a/tests/Feature/ConnectorRequestTest.php
+++ b/tests/Feature/ConnectorRequestTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use Sammyjo20\Saloon\Exceptions\InvalidRequestKeyException;
 use Sammyjo20\Saloon\Http\AnonymousRequestCollection;
 use Sammyjo20\Saloon\Exceptions\ClassNotFoundException;
+use Sammyjo20\Saloon\Tests\Fixtures\Collections\GuessedCollection;
+use Sammyjo20\Saloon\Tests\Fixtures\Connectors\InvalidServiceRequestConnector;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use Sammyjo20\Saloon\Exceptions\SaloonInvalidRequestException;
@@ -116,4 +119,20 @@ test('a connector request collection can be defined', function () {
 
     expect($request)->toBeInstanceOf(UserCollection::class);
     expect($request->test())->toBeTrue();
+});
+
+test('it throws an exception if you do not key an array of requests', function () {
+    $connector = new InvalidServiceRequestConnector();
+
+    $this->expectException(InvalidRequestKeyException::class);
+    $this->expectDeprecationMessage('Request groups must be keyed.');
+
+    $connector->custom();
+});
+
+test('it can guess the name of a collection', function () {
+    $connector = new ServiceRequestConnector;
+    $collection = $connector->guessedCollection();
+
+    expect($collection)->toBeInstanceOf(GuessedCollection::class);
 });

--- a/tests/Feature/ConnectorRequestTest.php
+++ b/tests/Feature/ConnectorRequestTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use Sammyjo20\Saloon\Exceptions\ClassNotFoundException;
 use Sammyjo20\Saloon\Http\AnonymousRequestCollection;
-use Sammyjo20\Saloon\Tests\Fixtures\Collections\UserCollection;
-use Sammyjo20\Saloon\Tests\Fixtures\Connectors\ServiceRequestConnector;
+use Sammyjo20\Saloon\Exceptions\ClassNotFoundException;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use Sammyjo20\Saloon\Exceptions\SaloonInvalidRequestException;
+use Sammyjo20\Saloon\Tests\Fixtures\Collections\UserCollection;
 use Sammyjo20\Saloon\Exceptions\SaloonConnectorMethodNotFoundException;
+use Sammyjo20\Saloon\Tests\Fixtures\Connectors\ServiceRequestConnector;
 use Sammyjo20\Saloon\Tests\Fixtures\Connectors\RequestSelectionConnector;
 use Sammyjo20\Saloon\Tests\Fixtures\Connectors\InvalidRequestSelectionConnector;
 use Sammyjo20\Saloon\Tests\Fixtures\Connectors\InvalidDefinedRequestSelectionConnector;

--- a/tests/Feature/ConnectorRequestTest.php
+++ b/tests/Feature/ConnectorRequestTest.php
@@ -118,7 +118,7 @@ test('a connector request collection can be defined', function () {
     $request = $connector->custom();
 
     expect($request)->toBeInstanceOf(UserCollection::class);
-    expect($request->test())->toBeTrue();
+    expect($request->get())->toBeInstanceOf(UserRequest::class);
 });
 
 test('it throws an exception if you do not key an array of requests', function () {

--- a/tests/Fixtures/Collections/GuessedCollection.php
+++ b/tests/Fixtures/Collections/GuessedCollection.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sammyjo20\Saloon\Tests\Fixtures\Collections;
+
+use Sammyjo20\Saloon\Http\RequestCollection;
+
+class GuessedCollection extends RequestCollection
+{
+    public function test(): bool
+    {
+        // Has access to $this->connector
+
+        return true;
+    }
+}

--- a/tests/Fixtures/Collections/UserCollection.php
+++ b/tests/Fixtures/Collections/UserCollection.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Sammyjo20\Saloon\Tests\Fixtures\Collections;
+
+use Sammyjo20\Saloon\Http\RequestCollection;
+
+class UserCollection extends RequestCollection
+{
+    public function test(): bool
+    {
+        // Has access to $this->connector
+
+        return true;
+    }
+}

--- a/tests/Fixtures/Collections/UserCollection.php
+++ b/tests/Fixtures/Collections/UserCollection.php
@@ -3,13 +3,16 @@
 namespace Sammyjo20\Saloon\Tests\Fixtures\Collections;
 
 use Sammyjo20\Saloon\Http\RequestCollection;
+use Sammyjo20\Saloon\Http\SaloonRequest;
+use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
 
 class UserCollection extends RequestCollection
 {
-    public function test(): bool
+    /**
+     * @return SaloonRequest
+     */
+    public function get(): SaloonRequest
     {
-        // Has access to $this->connector
-
-        return true;
+        return $this->connector->request(new UserRequest);
     }
 }

--- a/tests/Fixtures/Connectors/InvalidServiceRequestConnector.php
+++ b/tests/Fixtures/Connectors/InvalidServiceRequestConnector.php
@@ -3,13 +3,12 @@
 namespace Sammyjo20\Saloon\Tests\Fixtures\Connectors;
 
 use Sammyjo20\Saloon\Http\SaloonConnector;
-use Sammyjo20\Saloon\Tests\Fixtures\Collections\GuessedCollection;
 use Sammyjo20\Saloon\Traits\Plugins\AcceptsJson;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Collections\UserCollection;
 
-class ServiceRequestConnector extends SaloonConnector
+class InvalidServiceRequestConnector extends SaloonConnector
 {
     use AcceptsJson;
 
@@ -19,12 +18,9 @@ class ServiceRequestConnector extends SaloonConnector
      * @var array|string[]
      */
     protected array $requests = [
-        'user' => [
+        [
             'get' => UserRequest::class,
         ],
-        'custom' => UserCollection::class,
-        ErrorRequest::class,
-        GuessedCollection::class,
     ];
 
     /**

--- a/tests/Fixtures/Connectors/ServiceRequestConnector.php
+++ b/tests/Fixtures/Connectors/ServiceRequestConnector.php
@@ -19,7 +19,12 @@ class ServiceRequestConnector extends SaloonConnector
      * @var array|string[]
      */
     protected array $requests = [
-        'user' => UserCollection::class,
+        'user' => [
+            'get' => UserRequest::class,
+        ],
+        'custom' => UserCollection::class,
+        ErrorRequest::class,
+        GuessedCollection::class,
     ];
 
     /**

--- a/tests/Fixtures/Connectors/ServiceRequestConnector.php
+++ b/tests/Fixtures/Connectors/ServiceRequestConnector.php
@@ -19,12 +19,7 @@ class ServiceRequestConnector extends SaloonConnector
      * @var array|string[]
      */
     protected array $requests = [
-        'user' => [
-            'get' => UserRequest::class,
-        ],
-        'custom' => UserCollection::class,
-        ErrorRequest::class,
-        GuessedCollection::class,
+        'user' => UserCollection::class,
     ];
 
     /**

--- a/tests/Fixtures/Connectors/ServiceRequestConnector.php
+++ b/tests/Fixtures/Connectors/ServiceRequestConnector.php
@@ -3,10 +3,10 @@
 namespace Sammyjo20\Saloon\Tests\Fixtures\Connectors;
 
 use Sammyjo20\Saloon\Http\SaloonConnector;
-use Sammyjo20\Saloon\Tests\Fixtures\Collections\UserCollection;
 use Sammyjo20\Saloon\Traits\Plugins\AcceptsJson;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\ErrorRequest;
+use Sammyjo20\Saloon\Tests\Fixtures\Collections\UserCollection;
 
 class ServiceRequestConnector extends SaloonConnector
 {

--- a/tests/Fixtures/Connectors/ServiceRequestConnector.php
+++ b/tests/Fixtures/Connectors/ServiceRequestConnector.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Sammyjo20\Saloon\Tests\Fixtures\Connectors;
+
+use Sammyjo20\Saloon\Http\SaloonConnector;
+use Sammyjo20\Saloon\Tests\Fixtures\Collections\UserCollection;
+use Sammyjo20\Saloon\Traits\Plugins\AcceptsJson;
+use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
+use Sammyjo20\Saloon\Tests\Fixtures\Requests\ErrorRequest;
+
+class ServiceRequestConnector extends SaloonConnector
+{
+    use AcceptsJson;
+
+    /**
+     * Manually specify requests that the connector will register as methods
+     *
+     * @var array|string[]
+     */
+    protected array $requests = [
+        'user' => [
+            'get' => UserRequest::class,
+        ],
+        'custom' => UserCollection::class,
+        ErrorRequest::class,
+    ];
+
+    /**
+     * Define the base url of the api.
+     *
+     * @return string
+     */
+    public function defineBaseUrl(): string
+    {
+        return apiUrl();
+    }
+
+    /**
+     * Define the base headers that will be applied in every request.
+     *
+     * @return string[]
+     */
+    public function defaultHeaders(): array
+    {
+        return [];
+    }
+
+    public function __construct(public ?string $apiKey = null)
+    {
+        //
+    }
+}


### PR DESCRIPTION
Previously you could define custom methods on the connector to call requests in Saloon.

```php
protected array $requests = [
    'getMyUser' => UserRequest::class,
    ErrorRequest::class,
];
```

This was pretty limited as you couldn't define "groups" of requests. 

This PR introduces an extension to this API and now you can define an array of requests, keyed for a collection or a custom "RequestCollection" which is a class that extends the base "RequestCollection" class and can have completely custom methods inside. You will also have access to the connector.

### Define groups of requests

`$connector->user()->get()`

```php
protected array $requests = [
    'user' => [
        'get' => UserRequest::class,
    ],
];
```

### Define custom request collections

`$connector->user()->get()`

```php
protected array $requests = [
    'user' => UserCollection::class,
];
```

```php
class UserCollection extends RequestCollection
{
    public function get(): SaloonRequest
    {
        return $this->connector->request(new UserRequest);
    }
}
```