### PR TITLE
Make PluginManager respect plugin traits used by request & connector's parent class

### DIFF
--- a/src/Traits/ManagesPlugins.php
+++ b/src/Traits/ManagesPlugins.php
@@ -2,8 +2,6 @@
 
 namespace Sammyjo20\Saloon\Traits;
 
-use ReflectionClass;
-
 trait ManagesPlugins
 {
     /**
@@ -24,8 +22,8 @@ trait ManagesPlugins
         // any options. E.g if they have the "hasBody" interface, we need to add the
         // body to the request.
 
-        $connectorTraits = (new ReflectionClass($this->request->getConnector()))->getTraits();
-        $requestTraits = (new ReflectionClass($this->request))->getTraits();
+        $connectorTraits = class_uses_recursive($this->request->getConnector());
+        $requestTraits = class_uses_recursive($this->request);
 
         $this->scanTraits($connectorTraits, 'connector')
             ->scanTraits($requestTraits, 'request');
@@ -46,7 +44,7 @@ trait ManagesPlugins
         }
 
         foreach ($traits as $trait) {
-            $pluginName = $trait->getShortName();
+            $pluginName = class_basename($trait);
 
             if (in_array($pluginName, $this->plugins, true)) {
                 continue;
@@ -54,7 +52,7 @@ trait ManagesPlugins
 
             $bootName = 'boot' . $pluginName;
 
-            if ($trait->hasMethod($bootName) === false) {
+            if (method_exists($trait, $bootName) === false) {
                 continue;
             }
 

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -3,10 +3,10 @@
 use Sammyjo20\Saloon\Http\MockResponse;
 use Sammyjo20\Saloon\Clients\MockClient;
 use Sammyjo20\Saloon\Http\SaloonRequest;
-use Sammyjo20\Saloon\Tests\Fixtures\Mocking\CallableMockResponse;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Sammyjo20\Saloon\Tests\Fixtures\Mocking\CallableMockResponse;
 use Sammyjo20\Saloon\Exceptions\SaloonNoMockResponsesProvidedException;
 use Sammyjo20\Saloon\Tests\Fixtures\Connectors\QueryParameterConnector;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\DifferentServiceUserRequest;

--- a/tests/Fixtures/Mocking/CallableMockResponse.php
+++ b/tests/Fixtures/Mocking/CallableMockResponse.php
@@ -4,7 +4,6 @@ namespace Sammyjo20\Saloon\Tests\Fixtures\Mocking;
 
 use Sammyjo20\Saloon\Http\MockResponse;
 use Sammyjo20\Saloon\Http\SaloonRequest;
-use Sammyjo20\Saloon\Http\SaloonResponse;
 
 class CallableMockResponse
 {

--- a/tests/Fixtures/Requests/SubRequest.php
+++ b/tests/Fixtures/Requests/SubRequest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Sammyjo20\Saloon\Tests\Fixtures\Requests;
+
+class SubRequest extends UserRequestWithBootPlugin
+{
+}

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -1,10 +1,19 @@
 <?php
 
 use Sammyjo20\Saloon\Managers\RequestManager;
+use Sammyjo20\Saloon\Tests\Fixtures\Requests\SubRequest;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequestWithBootPlugin;
 
 test('a plugin boot method has access to the request', function () {
     $requestManager = new RequestManager(new UserRequestWithBootPlugin(1, 2));
+    $requestManager->hydrate();
+
+    expect($requestManager->getHeaders())->toHaveKey('X-Plugin-User-Id', 1);
+    expect($requestManager->getHeaders())->toHaveKey('X-Plugin-Group-Id', 2);
+});
+
+test('sub-request does not need to use plugins', function () {
+    $requestManager = new RequestManager(new SubRequest(1, 2));
     $requestManager->hydrate();
 
     expect($requestManager->getHeaders())->toHaveKey('X-Plugin-User-Id', 1);


### PR DESCRIPTION
Says there is a base request:

```
class BaseRequest extends SaloonRequest {
    use HasJsonBody;
}
```

And a subclass:

```
class SubRequest extends BaseRequest {
    public function defaultData(): array {
        return ['foo' => 'bar'];
    }
}
```

```
$requestManager = new RequestManager(new SubRequest());
$requestManager->hydrate();
// Before: null
// After: ["foo" => "bar"]
dump($request->getConfig('json'));

```


We can enhance this quite easily thanks to Laravel's helper functions.