### PR TITLE
fix response DTO type-hint

### DIFF
--- a/src/Http/SaloonResponse.php
+++ b/src/Http/SaloonResponse.php
@@ -193,7 +193,7 @@ class SaloonResponse
     /**
      * Cast the response to a DTO.
      *
-     * @return object|null
+     * @return mixed
      */
     public function dto(): mixed
     {


### PR DESCRIPTION
The native type-hint is `mixed` - like everywhere else - but the php-doc type-hint says `object|null` which will be true in most cases but it's possible and `mixed` allows it to also return a scalar value.
Even if it's not the primary/intended use case the whole package allows to return of a single scalar value.

This is helpful for APIs which also only return a single value - like success, number of something or similar.
For example the @ecologi public reporting API:
* https://docs.ecologi.com/docs/public-api-docs/2531efb510c5b-get-total-number-of-trees
* https://docs.ecologi.com/docs/public-api-docs/6046ba6f68449-get-total-tonnes-of-co-2e-offset

This PRsadjusts the php-doc type to match the native one. And solves phpstan errors like the following:
```
RequestCollections/Reporting.php                                                                                        

Method Astrotomic\Ecologi\RequestCollections\Reporting::getTrees() should return int but returns object|null.           
Method Astrotomic\Ecologi\RequestCollections\Reporting::getCarbonOffset() should return float but returns object|null.  
```

I assume that this fix should also be applied to the v2 - but haven't checked yet if this problem still exists.