### PR TITLE
enhance: UrlHelper join method handle endpoint URL string

### DIFF
--- a/src/Helpers/URLHelper.php
+++ b/src/Helpers/URLHelper.php
@@ -27,6 +27,10 @@ class URLHelper
      */
     public static function join(string $baseUrl, string $endpoint): string
     {
+        if (static::isValidUrl($endpoint)) {
+            return $endpoint;
+        }
+
         if ($endpoint !== '/') {
             $endpoint = ltrim($endpoint, '/ ');
         }
@@ -35,11 +39,13 @@ class URLHelper
 
         $baseEndpoint = rtrim($baseUrl, '/ ');
 
-        $endpointIsNotUrl = empty(filter_var($endpoint, FILTER_VALIDATE_URL));
-        $glue = $endpointIsNotUrl ? '/' : null;
-
-        $baseEndpoint = $requiresTrailingSlash ? $baseEndpoint . $glue : $baseEndpoint;
+        $baseEndpoint = $requiresTrailingSlash ? $baseEndpoint . '/' : $baseEndpoint;
 
         return $baseEndpoint . $endpoint;
+    }
+
+    public static function isValidUrl(string $url): bool
+    {
+        return ! empty(filter_var($url, FILTER_VALIDATE_URL));
     }
 }

--- a/tests/Unit/URLHelperTest.php
+++ b/tests/Unit/URLHelperTest.php
@@ -12,4 +12,5 @@ test('the URL helper will join two URLs together', function ($baseUrl, $endpoint
     ['https://google.com//', '//search', 'https://google.com/search'],
     ['', 'https://google.com/search', 'https://google.com/search'],
     ['', 'google.com/search', '/google.com/search'],
+    ['https://google.com', 'https://api.google.com/search', 'https://api.google.com/search'],
 ]);


### PR DESCRIPTION
This is to allow API endpoints to be full URLs and not have the baseUrl prepended to it. Closes issue #99