### PR TITLE
Feature | Added new dom() method for parsing HTML and XML

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,11 @@
         "friendsofphp/php-cs-fixer": "^3.5",
         "league/flysystem": "^3.0",
         "pestphp/pest": "^1.21",
-        "spatie/ray": "^1.33"
+        "spatie/ray": "^1.33",
+        "symfony/dom-crawler": "^6.1"
+    },
+    "suggest": {
+        "symfony/dom-crawler": "Required for the SaloonResponse dom() method to parse HTML and XML."
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "league/flysystem": "^3.0",
         "pestphp/pest": "^1.21",
         "spatie/ray": "^1.33",
-        "symfony/dom-crawler": "^6.1"
+        "symfony/dom-crawler": "^6.0"
     },
     "suggest": {
         "symfony/dom-crawler": "Required for the SaloonResponse dom() method to parse HTML and XML."

--- a/src/Http/SaloonResponse.php
+++ b/src/Http/SaloonResponse.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Collection;
 use Psr\Http\Message\StreamInterface;
 use Illuminate\Support\Traits\Macroable;
+use Symfony\Component\DomCrawler\Crawler;
 use GuzzleHttp\Exception\RequestException;
 use Sammyjo20\Saloon\Exceptions\SaloonRequestException;
 
@@ -198,6 +199,19 @@ class SaloonResponse
     public function dto(): mixed
     {
         return $this->dto;
+    }
+
+    /**
+     * Parse the HTML or XML body into a Symfony DomCrawler instance.
+     *
+     * Requires Symfony Crawler (composer require symfony/dom-crawler)
+     * @see https://symfony.com/doc/current/components/dom_crawler.html
+     *
+     * @return Crawler
+     */
+    public function dom(): Crawler
+    {
+        return new Crawler($this->body());
     }
 
     /**

--- a/tests/Unit/SaloonResponseTest.php
+++ b/tests/Unit/SaloonResponseTest.php
@@ -4,6 +4,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Collection;
 use Sammyjo20\Saloon\Http\MockResponse;
 use Sammyjo20\Saloon\Clients\MockClient;
+use Symfony\Component\DomCrawler\Crawler;
 use Sammyjo20\Saloon\Exceptions\SaloonRequestException;
 use Sammyjo20\Saloon\Tests\Fixtures\Requests\UserRequest;
 
@@ -196,4 +197,17 @@ test('the xml method will return xml as an array', function () {
     $simpleXml = $response->xml();
 
     expect($simpleXml)->toBeInstanceOf(SimpleXMLElement::class);
+});
+
+test('the dom method will return a crawler instance', function () {
+    $dom = '<p>Howdy <i>Partner</i></p>';
+
+    $mockClient = new MockClient([
+        new MockResponse($dom, 200),
+    ]);
+
+    $response = (new UserRequest())->send($mockClient);
+
+    expect($response->dom())->toBeInstanceOf(Crawler::class);
+    expect($response->dom())->toEqual(new Crawler($dom));
 });


### PR DESCRIPTION
This PR introduces a new method for the SaloonResponse, a new `dom()` method. This method requires Symfony's DomCrawler package and is not installed by default. This method will allow you to easily parse HTML or XML responses.

Read more about DomCrawler: https://symfony.com/doc/current/components/dom_crawler.html