### PR TITLE
Fixed handler stack

### DIFF
--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -242,9 +242,9 @@ interface Response
      * Get a header from the response.
      *
      * @param string $header
-     * @return string|null
+     * @return string|array|null
      */
-    public function header(string $header): ?string;
+    public function header(string $header): string|array|null;
 
     /**
      * Close the stream and any underlying resources.

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -84,9 +84,7 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
      */
     public function executeRequestPipeline(PendingRequest $pendingRequest): PendingRequest
     {
-        $this->requestPipeline->process($pendingRequest);
-
-        return $pendingRequest;
+        return $this->requestPipeline->process($pendingRequest);
     }
 
     /**
@@ -97,9 +95,7 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
      */
     public function executeResponsePipeline(Response $response): Response
     {
-        $this->responsePipeline->process($response);
-
-        return $response;
+        return $this->responsePipeline->process($response);
     }
 
     /**

--- a/src/Http/Responses/Response.php
+++ b/src/Http/Responses/Response.php
@@ -126,7 +126,11 @@ class Response implements ResponseContract
      */
     public function headers(): ArrayStore
     {
-        return new ArrayStore($this->rawResponse->getHeaders());
+        $headers = array_map(static function (array $header) {
+            return count($header) === 1 ? $header[0] : $header;
+        }, $this->rawResponse->getHeaders());
+
+        return new ArrayStore($headers);
     }
 
     /**

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Saloon\Http\Senders;
 
 use Exception;
-use GuzzleHttp\Utils;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use Saloon\Contracts\Sender;
@@ -68,29 +67,24 @@ class GuzzleSender implements Sender
      */
     protected function createGuzzleClient(): GuzzleClient
     {
-        $this->handlerStack = $this->createHandlerStack();
+        // We'll use HandlerStack::create as it will create a default
+        // handler stack with the default Guzzle middleware like
+        // http_errors, cookies etc.
+
+        $this->handlerStack = HandlerStack::create();
+
+        // Next we will define some Saloon defaults.
 
         $clientConfig = [
             'connect_timeout' => 10,
             'timeout' => 30,
-            'http_errors' => false,
+            'http_errors' => true,
             'handler' => $this->handlerStack,
         ];
 
+        // Something wrong with defining our own handler stack!
+
         return new GuzzleClient($clientConfig);
-    }
-
-    /**
-     * Create a blank handler stack.
-     *
-     * @return HandlerStack
-     */
-    protected function createHandlerStack(): HandlerStack
-    {
-        $stack = new HandlerStack();
-        $stack->setHandler(Utils::chooseHandler());
-
-        return $stack;
     }
 
     /**

--- a/src/Traits/Responses/HasResponseHelpers.php
+++ b/src/Traits/Responses/HasResponseHelpers.php
@@ -260,9 +260,9 @@ trait HasResponseHelpers
      * Get a header from the response.
      *
      * @param string $header
-     * @return string|null
+     * @return string|array|null
      */
-    public function header(string $header): ?string
+    public function header(string $header): string|array|null
     {
         return $this->headers()->get($header);
     }

--- a/tests/Fixtures/Connectors/ArraySenderConnector.php
+++ b/tests/Fixtures/Connectors/ArraySenderConnector.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Connectors;
+
+use Saloon\Http\Connector;
+use Saloon\Traits\Plugins\AcceptsJson;
+use Saloon\Tests\Fixtures\Senders\ArraySender;
+
+class ArraySenderConnector extends Connector
+{
+    use AcceptsJson;
+
+    /**
+     * Define the default sender class
+     *
+     * @var string
+     */
+    protected string $defaultSender = ArraySender::class;
+
+    /**
+     * Define the base url of the api.
+     *
+     * @return string
+     */
+    public function defineBaseUrl(): string
+    {
+        return apiUrl();
+    }
+
+    /**
+     * Set the sender
+     *
+     * @param string $defaultSender
+     * @return $this
+     */
+    public function setDefaultSender(string $defaultSender): static
+    {
+        $this->defaultSender = $defaultSender;
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Senders/ArraySender.php
+++ b/tests/Fixtures/Senders/ArraySender.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Senders;
+
+use Saloon\Contracts\Sender;
+use Saloon\Http\Responses\Response;
+use Saloon\Contracts\PendingRequest;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+
+class ArraySender implements Sender
+{
+    /**
+     * Get the sender's response class
+     *
+     * @return string
+     */
+    public function getResponseClass(): string
+    {
+        return Response::class;
+    }
+
+    /**
+     * Send the request.
+     *
+     * @param PendingRequest $pendingRequest
+     * @param bool $asynchronous
+     * @return Response|PromiseInterface
+     */
+    public function sendRequest(PendingRequest $pendingRequest, bool $asynchronous = false): Response|PromiseInterface
+    {
+        $responseClass = $pendingRequest->getResponseClass();
+
+        return new $responseClass($pendingRequest, new GuzzleResponse(200, ['X-Fake' => true], 'Default'));
+    }
+}

--- a/tests/Unit/Plugins/HasTimeoutPluginTest.php
+++ b/tests/Unit/Plugins/HasTimeoutPluginTest.php
@@ -6,25 +6,24 @@ use Saloon\Http\Faking\MockClient;
 use Saloon\Managers\RequestManager;
 use Saloon\Http\Faking\MockResponse;
 use Psr\Http\Message\RequestInterface;
+use GuzzleHttp\Promise\FulfilledPromise;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\TimeoutRequest;
 use Saloon\Tests\Fixtures\Connectors\TimeoutConnector;
 
 test('a request is given a default timeout and connect timeout', function () {
-    $mockClient = new MockClient([new MockResponse()]);
-
     $request = UserRequest::make();
 
-    $request->addHandler('test', function (callable $handler) {
+    $request->sender()->addMiddleware(function (callable $handler) {
         return function (RequestInterface $request, array $options) use ($handler) {
-            expect($options['connect_timeout'])->toEqual(10.0);
-            expect($options['timeout'])->toEqual(30.0);
+            expect($options['connect_timeout'])->toEqual(10);
+            expect($options['timeout'])->toEqual(30);
 
-            return $handler($request, $options);
+            return new FulfilledPromise(MockResponse::make()->getPsrResponse());
         };
-    });
+    }, 'test');
 
-    $request->send($mockClient);
+    $request->send();
 });
 
 test('a request can set a timeout and connect timeout', function () {

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Tests\Fixtures\Senders\ArraySender;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Connectors\ArraySenderConnector;
+
+test('the default sender on all connectors is the guzzle sender', function () {
+    $connector = new TestConnector();
+    $sender = $connector->sender();
+
+    expect($sender)->toBeInstanceOf(GuzzleSender::class);
+
+    // Test the same instance is re-used
+
+    expect($connector->sender())->toBe($sender);
+});
+
+test('you can overwrite the sender on a connector', function () {
+    $connector = new ArraySenderConnector();
+    $sender = $connector->sender();
+
+    expect($sender)->toBeInstanceOf(ArraySender::class);
+    expect($connector->sender())->toBe($sender);
+
+    // Test using the connector with the custom sender
+
+    $request = new UserRequest();
+    $response = $connector->send($request);
+
+    expect($response->headers()->all())->toEqual(['X-Fake' => true]);
+    expect($response->body())->toEqual('Default');
+});
+
+test('it will throw an exception if the sender does not implement the sender interface', function () {
+    $connector = new ArraySenderConnector();
+    $connector->setDefaultSender(UserRequest::class);
+
+    $this->expectException(TypeError::class);
+    $this->expectExceptionMessage('Return value must be of type Saloon\Contracts\Sender, Saloon\Tests\Fixtures\Requests\UserRequest returned');
+
+    $connector->sender();
+});
+
+test('you can access the sender from the request', function () {
+    $request = new UserRequest;
+
+    $sender = $request->sender();
+
+    expect($sender)->toBeInstanceOf(GuzzleSender::class);
+
+    // Test the same instance is re-used
+
+    expect($request->sender())->toBe($sender);
+});


### PR DESCRIPTION
@Gummibeer I think you mentioned that Guzzle wasn't throwing exceptions on error requests, you were right - my old way of defining the handler stack meant the default middleware wasn't being applied. I've moved the logic to use the same as v1, and it works again now!