### PR TITLE
Fix | AlwaysThrowOnErrors Priority

### DIFF
--- a/src/Contracts/MiddlewarePipeline.php
+++ b/src/Contracts/MiddlewarePipeline.php
@@ -12,17 +12,19 @@ interface MiddlewarePipeline
      * Add a middleware before the request is sent
      *
      * @param callable $closure
+     * @param bool $prepend
      * @return $this
      */
-    public function onRequest(callable $closure): static;
+    public function onRequest(callable $closure, bool $prepend = false): static;
 
     /**
      * Add a middleware after the request is sent
      *
      * @param callable $closure
+     * @param bool $prepend
      * @return $this
      */
-    public function onResponse(callable $closure): static;
+    public function onResponse(callable $closure, bool $prepend = false): static;
 
     /**
      * Process the request pipeline.

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -38,9 +38,10 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
      * Add a middleware before the request is sent
      *
      * @param callable $closure
+     * @param bool $prepend
      * @return $this
      */
-    public function onRequest(callable $closure): static
+    public function onRequest(callable $closure, bool $prepend = false): static
     {
         $this->requestPipeline = $this->requestPipeline->pipe(function (PendingRequest $pendingRequest) use ($closure) {
             $result = $closure($pendingRequest);
@@ -54,7 +55,7 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
             }
 
             return $pendingRequest;
-        });
+        }, $prepend);
 
         return $this;
     }
@@ -63,15 +64,16 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
      * Add a middleware after the request is sent
      *
      * @param callable $closure
+     * @param bool $prepend
      * @return $this
      */
-    public function onResponse(callable $closure): static
+    public function onResponse(callable $closure, bool $prepend = false): static
     {
         $this->responsePipeline = $this->responsePipeline->pipe(function (Response $response) use ($closure) {
             $result = $closure($response);
 
             return $result instanceof Response ? $result : $response;
-        });
+        }, $prepend);
 
         return $this;
     }

--- a/src/Helpers/Pipeline.php
+++ b/src/Helpers/Pipeline.php
@@ -17,11 +17,16 @@ class Pipeline
      * Add a pipe to the pipeline.
      *
      * @param callable $pipe
+     * @param bool $prepend
      * @return $this
      */
-    public function pipe(callable $pipe): static
+    public function pipe(callable $pipe, bool $prepend = false): static
     {
-        $this->pipes[] = $pipe;
+        if ($prepend === true) {
+            array_unshift($this->pipes, $pipe);
+        } else {
+            $this->pipes[] = $pipe;
+        }
 
         return $this;
     }

--- a/src/Http/Middleware/DetermineMockResponse.php
+++ b/src/Http/Middleware/DetermineMockResponse.php
@@ -47,7 +47,7 @@ class DetermineMockResponse implements RequestMiddleware
         // middleware on the response to record the response.
 
         if (is_null($mockResponse) && $mockObject instanceof Fixture) {
-            $pendingRequest->middleware()->onResponse(new RecordFixture($mockObject));
+            $pendingRequest->middleware()->onResponse(new RecordFixture($mockObject), true);
         }
 
         return $pendingRequest;

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -2,18 +2,18 @@
 
 declare(strict_types=1);
 
-use Saloon\Exceptions\RequestException;
 use Saloon\Http\PendingRequest;
 use League\Flysystem\Filesystem;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
-use Saloon\Tests\Fixtures\Requests\AlwaysThrowRequest;
+use Saloon\Exceptions\RequestException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use League\Flysystem\Local\LocalFilesystemAdapter;
 use Saloon\Exceptions\NoMockResponseFoundException;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Requests\AlwaysThrowRequest;
 use Saloon\Tests\Fixtures\Mocking\CallableMockResponse;
 use Saloon\Tests\Fixtures\Connectors\QueryParameterConnector;
 use Saloon\Tests\Fixtures\Requests\DifferentServiceUserRequest;

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use Saloon\Exceptions\RequestException;
 use Saloon\Http\PendingRequest;
 use League\Flysystem\Filesystem;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Tests\Fixtures\Requests\AlwaysThrowRequest;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use League\Flysystem\Local\LocalFilesystemAdapter;
@@ -480,4 +482,22 @@ test('a fixture can be used within a closure mock', function () use ($filesystem
     ]);
 });
 
-// Add asynchronous tests...
+test('when using the AlwaysThrowRequest trait the response recorder will still record the response', function () {
+    $mockClient = new MockClient([
+        AlwaysThrowRequest::class => MockResponse::fixture('error'),
+    ]);
+
+    $exception = null;
+
+    try {
+        AlwaysThrowRequest::make()->send($mockClient);
+    } catch (Exception $exception) {
+        //
+    }
+
+    expect($exception)->toBeInstanceOf(RequestException::class);
+
+    $fixture = MockResponse::fixture('error')->getMockResponse();
+
+    expect($fixture)->toBeInstanceOf(MockResponse::class);
+});

--- a/tests/Unit/MiddlewarePipelineTest.php
+++ b/tests/Unit/MiddlewarePipelineTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\PendingRequest;
+use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Responses\Response;
+use Saloon\Http\Faking\MockResponse;
 use Saloon\Helpers\MiddlewarePipeline;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;


### PR DESCRIPTION
This fixes a bug with the `AlwaysThrowOnErrors` trait and the fixture recorder. Due to the traits being loaded before the fixture recorder - the exception was being thrown. I've added a new `prepend` parameter which will add a middleware to the top of the pipeline.

@Gummibeer - hope you are well! This should fix the issues you were having :) 