### PR TITLE
WIP: try to add generics

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,8 +5,14 @@
          colors="true"
 >
     <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
+        <testsuite name="Unit Test Suite">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature Test Suite">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Integration Test Suite">
+            <directory suffix="Test.php">./tests/Integration</directory>
         </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">

--- a/src/Contracts/PendingRequest.php
+++ b/src/Contracts/PendingRequest.php
@@ -9,6 +9,9 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Saloon\Contracts\Body\BodyRepository;
 use Saloon\Http\Faking\SimulatedResponsePayload;
 
+/**
+ * @template TRequest of \Saloon\Contracts\Request
+ */
 interface PendingRequest
 {
     /**
@@ -136,7 +139,7 @@ interface PendingRequest
     /**
      * Build up the request payload.
      *
-     * @param Request $request
+     * @param TRequest $request
      * @param MockClient|null $mockClient
      */
     public function __construct(Request $request, MockClient $mockClient = null);
@@ -152,7 +155,7 @@ interface PendingRequest
     /**
      * Get the request.
      *
-     * @return Request
+     * @return TRequest
      */
     public function getRequest(): Request;
 
@@ -223,7 +226,7 @@ interface PendingRequest
     /**
      * Send the PendingRequest
      *
-     * @return Response
+     * @return Response<TRequest>
      */
     public function send(): Response;
 

--- a/src/Contracts/Request.php
+++ b/src/Contracts/Request.php
@@ -172,7 +172,7 @@ interface Request
      * Create a pending request
      *
      * @param \Saloon\Contracts\MockClient|null $mockClient
-     * @return \Saloon\Contracts\PendingRequest
+     * @return \Saloon\Contracts\PendingRequest<static>
      */
     public function createPendingRequest(MockClient $mockClient = null): PendingRequest;
 

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -13,6 +13,9 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\ResponseInterface;
 use Saloon\Http\Faking\SimulatedResponsePayload;
 
+/**
+ * @template TRequest of \Saloon\Contracts\Request
+ */
 interface Response
 {
     /**
@@ -58,7 +61,7 @@ interface Response
     /**
      * Get the original request
      *
-     * @return Request
+     * @return TRequest
      */
     public function getRequest(): Request;
 

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -28,6 +28,11 @@ use Saloon\Laravel\Http\Middleware\FrameworkMiddleware;
 use Saloon\Traits\RequestProperties\HasRequestProperties;
 use Saloon\Contracts\PendingRequest as PendingRequestContract;
 
+/**
+ * @template TRequest of \Saloon\Contracts\Request
+ *
+ * @implements \Saloon\Contracts\PendingRequest<TRequest>
+ */
 class PendingRequest implements PendingRequestContract
 {
     use AuthenticatesRequests;
@@ -38,7 +43,7 @@ class PendingRequest implements PendingRequestContract
     /**
      * The request used by the instance.
      *
-     * @var \Saloon\Contracts\Request
+     * @var TRequest
      */
     protected Request $request;
 
@@ -87,7 +92,7 @@ class PendingRequest implements PendingRequestContract
     /**
      * Build up the request payload.
      *
-     * @param \Saloon\Contracts\Request $request
+     * @param TRequest $request
      * @param \Saloon\Contracts\MockClient|null $mockClient
      * @throws \ReflectionException
      * @throws \Saloon\Exceptions\PendingRequestException
@@ -298,7 +303,7 @@ class PendingRequest implements PendingRequestContract
     /**
      * Get the request.
      *
-     * @return \Saloon\Contracts\Request
+     * @return TRequest
      */
     public function getRequest(): Request
     {
@@ -401,7 +406,7 @@ class PendingRequest implements PendingRequestContract
     /**
      * Send the PendingRequest
      *
-     * @return \Saloon\Contracts\Response
+     * @return \Saloon\Contracts\Response<TRequest>
      */
     public function send(): Response
     {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -58,7 +58,7 @@ abstract class Request implements RequestContract
      * Create a pending request
      *
      * @param \Saloon\Contracts\MockClient|null $mockClient
-     * @return \Saloon\Http\PendingRequest
+     * @return \Saloon\Http\PendingRequest<static>
      * @throws \ReflectionException
      * @throws \Saloon\Exceptions\PendingRequestException
      */

--- a/src/Http/Responses/Response.php
+++ b/src/Http/Responses/Response.php
@@ -15,6 +15,12 @@ use Saloon\Traits\Responses\HasResponseHelpers;
 use Saloon\Http\Faking\SimulatedResponsePayload;
 use Saloon\Contracts\Response as ResponseContract;
 
+/**
+ * @template TRequest of \Saloon\Contracts\Request
+ *
+ * @implements \Saloon\Contracts\Response<TRequest>
+ * @uses \Saloon\Traits\Responses\HasResponseHelpers<TRequest>
+ */
 class Response implements ResponseContract
 {
     use Macroable;
@@ -72,7 +78,7 @@ class Response implements ResponseContract
     /**
      * Get the original request that created the response.
      *
-     * @return Request
+     * @return TRequest
      */
     public function getRequest(): Request
     {

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -14,9 +14,11 @@ trait SendsRequests
     /**
      * Send a request
      *
-     * @param \Saloon\Contracts\Request $request
+     * @template TRequest of \Saloon\Contracts\Request
+     *
+     * @param TRequest $request
      * @param \Saloon\Contracts\MockClient|null $mockClient
-     * @return \Saloon\Contracts\Response
+     * @return \Saloon\Contracts\Response<TRequest>
      */
     public function send(Request $request, MockClient $mockClient = null): Response
     {

--- a/src/Traits/Responses/HasResponseHelpers.php
+++ b/src/Traits/Responses/HasResponseHelpers.php
@@ -13,6 +13,9 @@ use Symfony\Component\DomCrawler\Crawler;
 use Saloon\Exceptions\InvalidConnectorException;
 use Saloon\Http\Faking\SimulatedResponsePayload;
 
+/**
+ * @template TRequest of \Saloon\Contracts\Request
+ */
 trait HasResponseHelpers
 {
     use HasSimulationMethods;

--- a/tests/Integration/App.php
+++ b/tests/Integration/App.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Integration;
+
+class App
+{
+    public function __construct(
+        public readonly int $appid,
+        public readonly ?string $name,
+    ) {
+    }
+}

--- a/tests/Integration/DtoGenericsTest.php
+++ b/tests/Integration/DtoGenericsTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Tests\Integration\SteamConnector;
+
+it('can resolve the dto return type based on generics', function (): void {
+    $connector = new SteamConnector();
+    $response = $connector->getAppList();
+    $response->getRequest()->foobar;
+    $apps = $response->dto();
+})->only();

--- a/tests/Integration/GetAppListRequest.php
+++ b/tests/Integration/GetAppListRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Integration;
+
+use Saloon\Http\Request;
+use Saloon\Contracts\Response;
+use Illuminate\Support\Collection;
+use Saloon\Traits\Request\CastDtoFromResponse;
+
+class GetAppListRequest extends Request
+{
+    use CastDtoFromResponse;
+
+    protected string $method = 'GET';
+
+    public string $foobar = 'baz';
+
+    public function defineEndpoint(): string
+    {
+        return '/ISteamApps/GetAppList/v2';
+    }
+
+    /**
+     * @param \Saloon\Contracts\Response $response
+     * @return \Illuminate\Support\Collection<array-key, \Saloon\Tests\Integration\App>
+     */
+    public function createDtoFromResponse(Response $response): Collection
+    {
+        return $response->collect('applist.apps')
+            ->map(fn (array $app) => new App(
+                appid: $app['appid'],
+                name: $app['name'] ?? null
+            ))
+            ->values();
+    }
+}

--- a/tests/Integration/SteamConnector.php
+++ b/tests/Integration/SteamConnector.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Integration;
+
+use Saloon\Http\Connector;
+use Saloon\Contracts\Response;
+use Saloon\Traits\Plugins\AcceptsJson;
+use Saloon\Traits\Plugins\AlwaysThrowsOnErrors;
+
+class SteamConnector extends Connector
+{
+    use AcceptsJson;
+    use AlwaysThrowsOnErrors;
+
+    public function defineBaseUrl(): string
+    {
+        return 'https://api.steampowered.com';
+    }
+
+    public function defaultQuery(): array
+    {
+        return array_filter([
+            'format' => 'json',
+        ]);
+    }
+
+    public function getAppList(): Response
+    {
+        $request = new GetAppListRequest();
+
+        return $this->send($request);
+    }
+}


### PR DESCRIPTION
I wasn't able to get it done or further. In my understanding that's the right way. But somehow PHPStorm doesn't fully understand. It works as soon as I'm adding some methods like the `createPendingRequest` one to the `GetAppListRequest` class itself with the more precise `@return \Saloon\Contracts\Response<\Saloon\Tests\Integration\GetAppListRequest>`. But that's not the goal and should work without. 🤔

* https://phpstan.org/blog/generics-in-php-using-phpdocs
* https://psalm.dev/docs/annotating_code/templated_annotations/