### PR TITLE
Feature | V2 Safe Body

### DIFF
--- a/src/Exceptions/BodyException.php
+++ b/src/Exceptions/BodyException.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Saloon\Exceptions;
 
 class BodyException extends SaloonException
 {
-
 }

--- a/src/Exceptions/BodyException.php
+++ b/src/Exceptions/BodyException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Saloon\Exceptions;
+
+class BodyException extends SaloonException
+{
+
+}

--- a/src/Traits/Body/ChecksForWithBody.php
+++ b/src/Traits/Body/ChecksForWithBody.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Saloon\Traits\Body;
 
+use Saloon\Http\PendingRequest;
 use Saloon\Contracts\Body\WithBody;
 use Saloon\Exceptions\BodyException;
-use Saloon\Http\PendingRequest;
 
 trait ChecksForWithBody
 {

--- a/src/Traits/Body/ChecksForWithBody.php
+++ b/src/Traits/Body/ChecksForWithBody.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Saloon\Traits\Body;
+
+use Saloon\Contracts\Body\WithBody;
+use Saloon\Exceptions\BodyException;
+use Saloon\Http\PendingRequest;
+
+trait ChecksForWithBody
+{
+    /**
+     * Check if the request or connector has the WithBody class.
+     *
+     * @param \Saloon\Http\PendingRequest $pendingRequest
+     * @return void
+     * @throws \Saloon\Exceptions\BodyException
+     */
+    public function bootChecksForWithBody(PendingRequest $pendingRequest): void
+    {
+        if ($pendingRequest->getRequest() instanceof WithBody || $pendingRequest->getConnector() instanceof WithBody) {
+            return;
+        }
+
+        throw new BodyException('You have added a body trait without adding the `WithBody` interface to your request/connector.');
+    }
+}

--- a/src/Traits/Body/ChecksForWithBody.php
+++ b/src/Traits/Body/ChecksForWithBody.php
@@ -23,6 +23,6 @@ trait ChecksForWithBody
             return;
         }
 
-        throw new BodyException('You have added a body trait without adding the `WithBody` interface to your request/connector.');
+        throw new BodyException(sprintf('You have added a body trait without adding the `%s` interface to your request/connector.', WithBody::class));
     }
 }

--- a/src/Traits/Body/HasBody.php
+++ b/src/Traits/Body/HasBody.php
@@ -8,6 +8,8 @@ use Saloon\Repositories\Body\StringBodyRepository;
 
 trait HasBody
 {
+    use ChecksForWithBody;
+
     /**
      * Body Repository
      *

--- a/src/Traits/Body/HasFormBody.php
+++ b/src/Traits/Body/HasFormBody.php
@@ -8,6 +8,8 @@ use Saloon\Repositories\Body\FormBodyRepository;
 
 trait HasFormBody
 {
+    use ChecksForWithBody;
+
     /**
      * Body Repository
      *

--- a/src/Traits/Body/HasJsonBody.php
+++ b/src/Traits/Body/HasJsonBody.php
@@ -9,6 +9,8 @@ use Saloon\Repositories\Body\JsonBodyRepository;
 
 trait HasJsonBody
 {
+    use ChecksForWithBody;
+
     /**
      * Body Repository
      *

--- a/src/Traits/Body/HasMultipartBody.php
+++ b/src/Traits/Body/HasMultipartBody.php
@@ -8,6 +8,8 @@ use Saloon\Repositories\Body\MultipartBodyRepository;
 
 trait HasMultipartBody
 {
+    use ChecksForWithBody;
+
     /**
      * Body Repository
      *

--- a/tests/Unit/BodyTraitTest.php
+++ b/tests/Unit/BodyTraitTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Saloon\Contracts\Body\WithBody;
+use Saloon\Enums\Method;
+use Saloon\Exceptions\BodyException;
+use Saloon\Helpers\Helpers;
+use Saloon\Http\Connector;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\Request;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Traits\Body\ChecksForWithBody;
+use Saloon\Traits\Body\HasBody;
+use Saloon\Traits\Body\HasFormBody;
+use Saloon\Traits\Body\HasJsonBody;
+use Saloon\Traits\Body\HasMultipartBody;
+use Saloon\Traits\Body\HasXmlBody;
+
+test('each of the body traits has the ChecksForWithBody trait added', function (string $trait) {
+    $uses = Helpers::classUsesRecursive($trait);
+
+    expect($uses)->toHaveKey(ChecksForWithBody::class, ChecksForWithBody::class);
+})->with([
+    HasBody::class,
+    HasFormBody::class,
+    HasJsonBody::class,
+    HasMultipartBody::class,
+    HasXmlBody::class,
+]);
+
+test('when a body trait is added to a request without WithBody it will throw an exception', function () {
+    $request = new class extends Request {
+        use HasJsonBody;
+
+        protected Method $method = Method::GET;
+
+        public function resolveEndpoint(): string
+        {
+            return '';
+        }
+    };
+
+    $this->expectException(BodyException::class);
+    $this->expectExceptionMessage('You have added a body trait without adding the `WithBody` interface to your request/connector.');
+
+    TestConnector::make()->send($request);
+});
+
+test('when a body trait is added to a connector without WithBody it will throw an exception', function () {
+    $connector = new class extends Connector {
+        use HasJsonBody;
+
+        public function resolveBaseUrl(): string
+        {
+            return '';
+        }
+    };
+
+    $this->expectException(BodyException::class);
+    $this->expectExceptionMessage('You have added a body trait without adding the `WithBody` interface to your request/connector.');
+
+    $connector->send(new UserRequest);
+});

--- a/tests/Unit/BodyTraitTest.php
+++ b/tests/Unit/BodyTraitTest.php
@@ -1,21 +1,20 @@
 <?php
 
-use Saloon\Contracts\Body\WithBody;
+declare(strict_types=1);
+
 use Saloon\Enums\Method;
-use Saloon\Exceptions\BodyException;
-use Saloon\Helpers\Helpers;
-use Saloon\Http\Connector;
-use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\Request;
-use Saloon\Tests\Fixtures\Connectors\TestConnector;
-use Saloon\Tests\Fixtures\Requests\UserRequest;
-use Saloon\Traits\Body\ChecksForWithBody;
+use Saloon\Http\Connector;
+use Saloon\Helpers\Helpers;
 use Saloon\Traits\Body\HasBody;
+use Saloon\Traits\Body\HasXmlBody;
 use Saloon\Traits\Body\HasFormBody;
 use Saloon\Traits\Body\HasJsonBody;
+use Saloon\Exceptions\BodyException;
 use Saloon\Traits\Body\HasMultipartBody;
-use Saloon\Traits\Body\HasXmlBody;
+use Saloon\Traits\Body\ChecksForWithBody;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
 
 test('each of the body traits has the ChecksForWithBody trait added', function (string $trait) {
     $uses = Helpers::classUsesRecursive($trait);

--- a/tests/Unit/BodyTraitTest.php
+++ b/tests/Unit/BodyTraitTest.php
@@ -41,7 +41,7 @@ test('when a body trait is added to a request without WithBody it will throw an 
     };
 
     $this->expectException(BodyException::class);
-    $this->expectExceptionMessage('You have added a body trait without adding the `WithBody` interface to your request/connector.');
+    $this->expectExceptionMessage('You have added a body trait without adding the `Saloon\Contracts\Body\WithBody` interface to your request/connector.');
 
     TestConnector::make()->send($request);
 });
@@ -57,7 +57,7 @@ test('when a body trait is added to a connector without WithBody it will throw a
     };
 
     $this->expectException(BodyException::class);
-    $this->expectExceptionMessage('You have added a body trait without adding the `WithBody` interface to your request/connector.');
+    $this->expectExceptionMessage('You have added a body trait without adding the `Saloon\Contracts\Body\WithBody` interface to your request/connector.');
 
     $connector->send(new UserRequest);
 });


### PR DESCRIPTION
I noticed an issue which could come up and annoy developers a bit which is the requirement to add both the `WithBody` interface and a body trait like `HasJsonBody` to make the body work.

In previous versions of Saloon, the `data` method was always available. From v2, the data method has been replaced with `body` but it's not included on the request/connector by default. It is only added when adding a trait. I also thought it would be good to require an interface so instead of doing fancy `method_exist` checks in the PendingRequest, I could quite easily just check if either the connector or request is an instanceof WithBody. This has some added benefits of knowing for certain that the `body` method had a specific return type.

The issue is that if someone adds a body trait without the interface, Saloon will send the request without the body and without error. So I decided to add a trait onto each body trait that will throw an exception if it detects either the connector or request doesn't have the WithBody trait. 

@Gummibeer @juse-less what are your thoughts on this, is this too "magical"? Should I let developers make their own mistakes? I just worry this is the kind of thing that a developer could fall down a bit rabbit hole trying to work out why their request isn't sending any data.