### PR TITLE
Fix | v2 Better Response Error Methods

### DIFF
--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -128,6 +128,13 @@ interface Response
     public function failed(): bool;
 
     /**
+     * Determine if the response should throw a request exception
+     *
+     * @return bool
+     */
+    public function shouldThrowRequestException(): bool;
+
+    /**
      * Determine if the response indicates a client error occurred.
      *
      * @return bool

--- a/src/Exceptions/Request/RequestException.php
+++ b/src/Exceptions/Request/RequestException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Exceptions\Request;
 
+use Saloon\Contracts\PendingRequest;
 use Throwable;
 use Saloon\Contracts\Response;
 use Saloon\Helpers\StatusCodeHelper;
@@ -57,6 +58,16 @@ class RequestException extends SaloonException
     public function getResponse(): Response
     {
         return $this->response;
+    }
+
+    /**
+     * Get the pending request.
+     *
+     * @return \Saloon\Contracts\PendingRequest
+     */
+    public function getPendingRequest(): PendingRequest
+    {
+        return $this->getResponse()->getPendingRequest();
     }
 
     /**

--- a/src/Exceptions/Request/RequestException.php
+++ b/src/Exceptions/Request/RequestException.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Saloon\Exceptions\Request;
 
-use Saloon\Contracts\PendingRequest;
 use Throwable;
 use Saloon\Contracts\Response;
+use Saloon\Contracts\PendingRequest;
 use Saloon\Helpers\StatusCodeHelper;
 use Saloon\Exceptions\SaloonException;
 

--- a/src/Traits/HandlesExceptions.php
+++ b/src/Traits/HandlesExceptions.php
@@ -17,7 +17,7 @@ trait HandlesExceptions
      */
     public function shouldThrowRequestException(Response $response): bool
     {
-        return $response->serverError() || $response->clientError();
+        return $response->failed();
     }
 
     /**

--- a/tests/Feature/RequestExceptionTest.php
+++ b/tests/Feature/RequestExceptionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Saloon\Contracts\PendingRequest;
 use Saloon\Contracts\Response;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
@@ -152,6 +153,7 @@ test('you can customise if saloon should throw an exception on a connector', fun
     $exceptionB = $responseB->toException();
 
     expect($exceptionB)->toBeInstanceOf(RequestException::class);
+    expect($exceptionB->getPendingRequest())->toBeInstanceOf(PendingRequest::class);
     expect($exceptionB->getResponse())->toBeInstanceOf(Response::class);
     expect($exceptionB->getMessage())->toEqual('OK (200) Response: ' . $exceptionB->getResponse()->body());
     expect($exceptionB->getPrevious())->toBeNull();
@@ -173,6 +175,7 @@ test('you can customise if saloon should throw an exception on a request', funct
     $exceptionB = $responseB->toException();
 
     expect($exceptionB)->toBeInstanceOf(RequestException::class);
+    expect($exceptionB->getPendingRequest())->toBeInstanceOf(PendingRequest::class);
     expect($exceptionB->getResponse())->toBeInstanceOf(Response::class);
     expect($exceptionB->getMessage())->toEqual('OK (200) Response: ' . $exceptionB->getResponse()->body());
     expect($exceptionB->getPrevious())->toBeNull();
@@ -195,6 +198,7 @@ test('when both the connector and request have custom logic to determine differe
     $exceptionB = $responseB->toException();
 
     expect($exceptionB)->toBeInstanceOf(RequestException::class);
+    expect($exceptionB->getPendingRequest())->toBeInstanceOf(PendingRequest::class);
     expect($exceptionB->getResponse())->toBeInstanceOf(Response::class);
     expect($exceptionB->getMessage())->toEqual('OK (200) Response: ' . $exceptionB->getResponse()->body());
     expect($exceptionB->getPrevious())->toBeNull();

--- a/tests/Feature/RequestExceptionTest.php
+++ b/tests/Feature/RequestExceptionTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Saloon\Contracts\PendingRequest;
 use Saloon\Contracts\Response;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Contracts\PendingRequest;
 use Saloon\Http\Faking\MockResponse;
 use GuzzleHttp\Exception\ServerException;
 use Saloon\Exceptions\Request\ClientException;

--- a/tests/Feature/RequestExceptionTest.php
+++ b/tests/Feature/RequestExceptionTest.php
@@ -144,11 +144,11 @@ test('you can customise if saloon should throw an exception on a connector', fun
 
     $responseA = BadResponseConnector::make()->send(new UserRequest, $mockClient);
 
-    expect($responseA->failed())->toBeFalse();
+    expect($responseA->shouldThrowRequestException())->toBeFalse();
     expect($responseA->toException())->toBeNull();
 
     $responseB = BadResponseConnector::make()->send(new UserRequest, $mockClient);
-    expect($responseB->failed())->toBeTrue();
+    expect($responseB->shouldThrowRequestException())->toBeTrue();
     $exceptionB = $responseB->toException();
 
     expect($exceptionB)->toBeInstanceOf(RequestException::class);
@@ -165,11 +165,11 @@ test('you can customise if saloon should throw an exception on a request', funct
 
     $responseA = TestConnector::make()->send(new BadResponseRequest, $mockClient);
 
-    expect($responseA->failed())->toBeFalse();
+    expect($responseA->shouldThrowRequestException())->toBeFalse();
     expect($responseA->toException())->toBeNull();
 
     $responseB = TestConnector::make()->send(new BadResponseRequest, $mockClient);
-    expect($responseB->failed())->toBeTrue();
+    expect($responseB->shouldThrowRequestException())->toBeTrue();
     $exceptionB = $responseB->toException();
 
     expect($exceptionB)->toBeInstanceOf(RequestException::class);
@@ -187,11 +187,11 @@ test('when both the connector and request have custom logic to determine differe
 
     $responseA = BadResponseConnector::make()->send(new BadResponseRequest, $mockClient);
 
-    expect($responseA->failed())->toBeFalse();
+    expect($responseA->shouldThrowRequestException())->toBeFalse();
     expect($responseA->toException())->toBeNull();
 
     $responseB = BadResponseConnector::make()->send(new BadResponseRequest, $mockClient);
-    expect($responseB->failed())->toBeTrue();
+    expect($responseB->shouldThrowRequestException())->toBeTrue();
     $exceptionB = $responseB->toException();
 
     expect($exceptionB)->toBeInstanceOf(RequestException::class);
@@ -200,7 +200,7 @@ test('when both the connector and request have custom logic to determine differe
     expect($exceptionB->getPrevious())->toBeNull();
 
     $responseC = BadResponseConnector::make()->send(new BadResponseRequest, $mockClient);
-    expect($responseC->failed())->toBeTrue();
+    expect($responseC->shouldThrowRequestException())->toBeTrue();
     $exceptionC = $responseC->toException();
 
     expect($exceptionC)->toBeInstanceOf(RequestException::class);


### PR DESCRIPTION
This PR changes the way that the response `throw` and `toException` methods work. Previously, it used the `failed()` method but now it uses a new `shouldThrowRequestException`.