### PR TITLE
Feature | V2 - Simplified responses and created one single response

### DIFF
--- a/src/Contracts/Connector.php
+++ b/src/Contracts/Connector.php
@@ -122,9 +122,9 @@ interface Connector
     /**
      * Get the response class
      *
-     * @return string
+     * @return string|null
      */
-    public function resolveResponseClass(): string;
+    public function resolveResponseClass(): ?string;
 
     /**
      * Access the headers

--- a/src/Contracts/PendingRequest.php
+++ b/src/Contracts/PendingRequest.php
@@ -180,7 +180,7 @@ interface PendingRequest
     /**
      * Get the response class used for the request
      *
-     * @return string
+     * @return mixed
      */
     public function getResponseClass(): string;
 

--- a/src/Contracts/Request.php
+++ b/src/Contracts/Request.php
@@ -122,9 +122,9 @@ interface Request
     /**
      * Get the response class
      *
-     * @return string
+     * @return string|null
      */
-    public function resolveResponseClass(): string;
+    public function resolveResponseClass(): ?string;
 
     /**
      * Access the headers

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -14,7 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 interface Response
 {
     /**
-     * Create an instance of the response
+     * Create an instance of the response from a PSR response
      *
      * @param \Saloon\Contracts\PendingRequest $pendingRequest
      * @param \Psr\Http\Message\ResponseInterface $psrResponse
@@ -22,6 +22,20 @@ interface Response
      * @return $this
      */
     public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, ?Throwable $senderException = null): static;
+
+    /**
+     * Create a PSR response from the raw response.
+     *
+     * @return ResponseInterface
+     */
+    public function getPsrResponse(): ResponseInterface;
+
+    /**
+     * Get the underlying PendingRequest that created the response
+     *
+     * @return PendingRequest
+     */
+    public function getPendingRequest(): PendingRequest;
 
     /**
      * Get the body of the response as string.
@@ -38,6 +52,13 @@ interface Response
     public function stream(): StreamInterface;
 
     /**
+     * Close the stream and any underlying resources.
+     *
+     * @return $this
+     */
+    public function close(): static;
+
+    /**
      * Get the headers from the response.
      *
      * @return ArrayStore
@@ -45,23 +66,19 @@ interface Response
     public function headers(): ArrayStore;
 
     /**
+     * Get a header from the response.
+     *
+     * @param string $header
+     * @return string|array|null
+     */
+    public function header(string $header): string|array|null;
+
+    /**
      * Get the status code of the response.
      *
      * @return int
      */
     public function status(): int;
-
-    /**
-     * Create a PSR response from the raw response.
-     *
-     * @return ResponseInterface
-     */
-    public function getPsrResponse(): ResponseInterface;
-
-    /**
-     * @return PendingRequest
-     */
-    public function getPendingRequest(): PendingRequest;
 
     /**
      * Get the original request
@@ -181,13 +198,6 @@ interface Response
     public function throw(): static;
 
     /**
-     * Get the body of the response.
-     *
-     * @return string
-     */
-    public function __toString(): string;
-
-    /**
      * Check if the response has been cached
      *
      * @return bool
@@ -254,17 +264,9 @@ interface Response
     public function getRawResponse(): mixed;
 
     /**
-     * Get a header from the response.
+     * Get the body of the response.
      *
-     * @param string $header
-     * @return string|array|null
+     * @return string
      */
-    public function header(string $header): string|array|null;
-
-    /**
-     * Close the stream and any underlying resources.
-     *
-     * @return $this
-     */
-    public function close(): static;
+    public function __toString(): string;
 }

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -21,7 +21,7 @@ interface Response
      * @param \Throwable|null $senderException
      * @return $this
      */
-    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, Throwable $senderException = null): static;
+    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, ?Throwable $senderException = null): static;
 
     /**
      * Get the body of the response as string.

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -21,7 +21,7 @@ interface Response
      * @param \Throwable|null $senderException
      * @return $this
      */
-    public static function create(PendingRequest $pendingRequest, ResponseInterface $psrResponse, Throwable $senderException = null): static;
+    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, Throwable $senderException = null): static;
 
     /**
      * Get the body of the response as string.

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -14,6 +14,16 @@ use Psr\Http\Message\ResponseInterface;
 interface Response
 {
     /**
+     * Create an instance of the response
+     *
+     * @param \Saloon\Contracts\PendingRequest $pendingRequest
+     * @param \Psr\Http\Message\ResponseInterface $psrResponse
+     * @param \Throwable|null $senderException
+     * @return $this
+     */
+    public static function create(PendingRequest $pendingRequest, ResponseInterface $psrResponse, Throwable $senderException = null): static;
+
+    /**
      * Get the body of the response as string.
      *
      * @return string

--- a/src/Contracts/Sender.php
+++ b/src/Contracts/Sender.php
@@ -9,13 +9,6 @@ use GuzzleHttp\Promise\PromiseInterface;
 interface Sender
 {
     /**
-     * Get the sender's response class
-     *
-     * @return string
-     */
-    public function getResponseClass(): string;
-
-    /**
      * Send the request.
      *
      * @param PendingRequest $pendingRequest

--- a/src/Exceptions/InvalidResponseClassException.php
+++ b/src/Exceptions/InvalidResponseClassException.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Saloon\Exceptions;
 
+use Saloon\Contracts\Response;
+
 class InvalidResponseClassException extends SaloonException
 {
     /**
@@ -13,6 +15,6 @@ class InvalidResponseClassException extends SaloonException
      */
     public function __construct(string $message = null)
     {
-        parent::__construct($message ?? 'The provided response must implement the Response contract.');
+        parent::__construct($message ?? sprintf('The provided response must exist and implement the %s contract.', Response::class));
     }
 }

--- a/src/Exceptions/SenderException.php
+++ b/src/Exceptions/SenderException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Exceptions;
+
+class SenderException extends SaloonException
+{
+    //
+}

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -20,18 +20,18 @@ class Response implements ResponseContract
     use HasResponseHelpers;
 
     /**
-     * The request options we attached to the request.
-     *
-     * @var PendingRequest
-     */
-    protected PendingRequest $pendingRequest;
-
-    /**
      * The PSR response from the sender.
      *
      * @var ResponseInterface|mixed
      */
     protected ResponseInterface $psrResponse;
+
+    /**
+     * The pending request that has all the request properties
+     *
+     * @var PendingRequest
+     */
+    protected PendingRequest $pendingRequest;
 
     /**
      * The original sender exception
@@ -47,10 +47,10 @@ class Response implements ResponseContract
      * @param ResponseInterface $psrResponse
      * @param Throwable|null $senderException
      */
-    public function __construct(PendingRequest $pendingRequest, ResponseInterface $psrResponse, Throwable $senderException = null)
+    public function __construct(ResponseInterface $psrResponse, PendingRequest $pendingRequest, Throwable $senderException = null)
     {
-        $this->pendingRequest = $pendingRequest;
         $this->psrResponse = $psrResponse;
+        $this->pendingRequest = $pendingRequest;
         $this->senderException = $senderException;
     }
 
@@ -156,8 +156,8 @@ class Response implements ResponseContract
      * @param \Throwable|null $senderException
      * @return $this
      */
-    public static function create(PendingRequest $pendingRequest, ResponseInterface $psrResponse, Throwable $senderException = null): static
+    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, Throwable $senderException = null): static
     {
-        return new static($pendingRequest, $psrResponse, $senderException);
+        return new static($psrResponse, $pendingRequest, $senderException);
     }
 }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -156,7 +156,7 @@ class Response implements ResponseContract
      * @param \Throwable|null $senderException
      * @return $this
      */
-    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, Throwable $senderException = null): static
+    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, ?Throwable $senderException = null): static
     {
         return new static($psrResponse, $pendingRequest, $senderException);
     }

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -55,6 +55,19 @@ class Response implements ResponseContract
     }
 
     /**
+     * Create a new response instance
+     *
+     * @param \Saloon\Contracts\PendingRequest $pendingRequest
+     * @param \Psr\Http\Message\ResponseInterface $psrResponse
+     * @param \Throwable|null $senderException
+     * @return $this
+     */
+    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, ?Throwable $senderException = null): static
+    {
+        return new static($psrResponse, $pendingRequest, $senderException);
+    }
+
+    /**
      * Get the pending request that created the response.
      *
      * @return PendingRequest
@@ -146,18 +159,5 @@ class Response implements ResponseContract
     public function getSenderException(): ?Throwable
     {
         return $this->senderException;
-    }
-
-    /**
-     * Create an instance of the response
-     *
-     * @param \Saloon\Contracts\PendingRequest $pendingRequest
-     * @param \Psr\Http\Message\ResponseInterface $psrResponse
-     * @param \Throwable|null $senderException
-     * @return $this
-     */
-    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, ?Throwable $senderException = null): static
-    {
-        return new static($psrResponse, $pendingRequest, $senderException);
     }
 }

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -179,11 +179,11 @@ class GuzzleSender implements Sender
         }
 
         match (true) {
-            $body instanceof JsonBodyRepository => $requestOptions['json'] = $body->all(),
-            $body instanceof MultipartBodyRepository => $requestOptions['multipart'] = $body->all(),
-            $body instanceof FormBodyRepository => $requestOptions['form_params'] = $body->all(),
-            $body instanceof StringBodyRepository => $requestOptions['body'] = $body->all(),
-            default => $requestOptions['body'] = (string)$body,
+            $body instanceof JsonBodyRepository => $requestOptions[RequestOptions::JSON] = $body->all(),
+            $body instanceof MultipartBodyRepository => $requestOptions[RequestOptions::MULTIPART] = $body->all(),
+            $body instanceof FormBodyRepository => $requestOptions[RequestOptions::FORM_PARAMS] = $body->all(),
+            $body instanceof StringBodyRepository => $requestOptions[RequestOptions::BODY] = $body->all(),
+            default => $requestOptions[RequestOptions::BODY] = (string)$body,
         };
 
         return $requestOptions;

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -202,7 +202,7 @@ class GuzzleSender implements Sender
         /** @var class-string<\Saloon\Contracts\Response> $responseClass */
         $responseClass = $pendingSaloonRequest->getResponseClass();
 
-        return $responseClass::create($pendingSaloonRequest, $guzzleResponse, $exception);
+        return $responseClass::fromPsrResponse($guzzleResponse, $pendingSaloonRequest, $exception);
     }
 
     /**

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -9,7 +9,6 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use Saloon\Contracts\Sender;
 use GuzzleHttp\RequestOptions;
-use Saloon\Http\Responses\Response;
 use Saloon\Contracts\PendingRequest;
 use GuzzleHttp\Client as GuzzleClient;
 use Psr\Http\Message\ResponseInterface;
@@ -47,16 +46,6 @@ class GuzzleSender implements Sender
     public function __construct()
     {
         $this->client = $this->createGuzzleClient();
-    }
-
-    /**
-     * Get the sender's response class
-     *
-     * @return string
-     */
-    public function getResponseClass(): string
-    {
-        return Response::class;
     }
 
     /**
@@ -210,9 +199,10 @@ class GuzzleSender implements Sender
      */
     protected function createResponse(PendingRequest $pendingSaloonRequest, ResponseInterface $guzzleResponse, Exception $exception = null): ResponseContract
     {
+        /** @var class-string<\Saloon\Contracts\Response> $responseClass */
         $responseClass = $pendingSaloonRequest->getResponseClass();
 
-        return new $responseClass($pendingSaloonRequest, $guzzleResponse, $exception);
+        return $responseClass::create($pendingSaloonRequest, $guzzleResponse, $exception);
     }
 
     /**

--- a/src/Http/Senders/SimulatedSender.php
+++ b/src/Http/Senders/SimulatedSender.php
@@ -41,9 +41,9 @@ class SimulatedSender implements Sender
         /** @var class-string<\Saloon\Contracts\Response> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
-        $response = $responseClass::create(
-            pendingRequest: $pendingRequest,
+        $response = $responseClass::fromPsrResponse(
             psrResponse: $simulatedResponsePayload->getPsrResponse(),
+            pendingRequest: $pendingRequest,
             senderException: $exception
         );
 

--- a/src/Http/Senders/SimulatedSender.php
+++ b/src/Http/Senders/SimulatedSender.php
@@ -5,48 +5,46 @@ declare(strict_types=1);
 namespace Saloon\Http\Senders;
 
 use Throwable;
+use Saloon\Http\Response;
 use Saloon\Contracts\Sender;
-use Saloon\Http\Responses\Response;
 use Saloon\Contracts\PendingRequest;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Exceptions\SenderException;
 use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
+use Saloon\Contracts\SimulatedResponsePayload;
 use Saloon\Contracts\Response as ResponseContract;
 
 class SimulatedSender implements Sender
 {
-    /**
-     * Get the sender's response class
-     *
-     * @return string
-     */
-    public function getResponseClass(): string
-    {
-        return Response::class;
-    }
-
     /**
      * Send the request.
      *
      * @param PendingRequest $pendingRequest
      * @param bool $asynchronous
      * @return Response|PromiseInterface
+     * @throws \Saloon\Exceptions\SenderException
      */
     public function sendRequest(PendingRequest $pendingRequest, bool $asynchronous = false): ResponseContract|PromiseInterface
     {
         $simulatedResponsePayload = $pendingRequest->getSimulatedResponsePayload();
-        $exception = $simulatedResponsePayload?->getException($pendingRequest);
+
+        if (! $simulatedResponsePayload instanceof SimulatedResponsePayload) {
+            throw new SenderException('Simulated response payload must be present on the pending request instance');
+        }
+
+        $exception = $simulatedResponsePayload->getException($pendingRequest);
 
         // When the pending request instance has SimulatedResponsePayload it means
         // we shouldn't send a real request. We can convert the payload into
         // a PSR-compatible ResponseInterface class which means we can use
         // can also make use of custom responses.
 
+        /** @var class-string<\Saloon\Contracts\Response> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
-        /** @var \Saloon\Contracts\Response $response */
-        $response = new $responseClass($pendingRequest, $simulatedResponsePayload, $exception);
+        $response = $responseClass::create($pendingRequest, $simulatedResponsePayload->getPsrResponse(), $exception);
 
         // When the SimulatedResponsePayload is specifically a MockResponse then
         // we will record the response, and we'll set the "isMocked" property

--- a/src/Http/Senders/SimulatedSender.php
+++ b/src/Http/Senders/SimulatedSender.php
@@ -34,17 +34,18 @@ class SimulatedSender implements Sender
             throw new SenderException('Simulated response payload must be present on the pending request instance');
         }
 
-        $exception = $simulatedResponsePayload->getException($pendingRequest);
+        // Let's create our response!
 
-        // When the pending request instance has SimulatedResponsePayload it means
-        // we shouldn't send a real request. We can convert the payload into
-        // a PSR-compatible ResponseInterface class which means we can use
-        // can also make use of custom responses.
+        $exception = $simulatedResponsePayload->getException($pendingRequest);
 
         /** @var class-string<\Saloon\Contracts\Response> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
-        $response = $responseClass::create($pendingRequest, $simulatedResponsePayload->getPsrResponse(), $exception);
+        $response = $responseClass::create(
+            pendingRequest: $pendingRequest,
+            psrResponse: $simulatedResponsePayload->getPsrResponse(),
+            senderException: $exception
+        );
 
         // When the SimulatedResponsePayload is specifically a MockResponse then
         // we will record the response, and we'll set the "isMocked" property
@@ -67,7 +68,8 @@ class SimulatedSender implements Sender
         }
 
         // When mocking asynchronous requests we need to wrap the response
-        // in FulfilledPromise to act like a real response.
+        // in FulfilledPromise or RejectedPromise depending on if the
+        // response has an exception.
 
         $exception ??= $response->toException();
 

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -6,9 +6,9 @@ namespace Saloon\Traits\OAuth2;
 
 use DateTimeImmutable;
 use Saloon\Helpers\Date;
+use Saloon\Http\Response;
 use Saloon\Helpers\URLHelper;
 use Saloon\Helpers\StateHelper;
-use Saloon\Http\Responses\Response;
 use Saloon\Helpers\OAuth2\OAuthConfig;
 use Saloon\Http\OAuth2\GetUserRequest;
 use Saloon\Contracts\OAuthAuthenticator;

--- a/src/Traits/Responses/HasCustomResponses.php
+++ b/src/Traits/Responses/HasCustomResponses.php
@@ -11,16 +11,16 @@ trait HasCustomResponses
      *
      * When an empty string, the response on the sender will be used.
      *
-     * @var string
+     * @var string|null
      */
-    protected string $response = '';
+    protected ?string $response = null;
 
     /**
      * Resolve the custom response class
      *
-     * @return string
+     * @return string|null
      */
-    public function resolveResponseClass(): string
+    public function resolveResponseClass(): ?string
     {
         return $this->response;
     }

--- a/tests/Feature/AsyncRequestTest.php
+++ b/tests/Feature/AsyncRequestTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Response;
 use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use GuzzleHttp\Promise\PromiseInterface;
 use Saloon\Tests\Fixtures\Responses\UserData;

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
 use League\Flysystem\Filesystem;
 use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Exceptions\Request\RequestException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;

--- a/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
+++ b/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 use Saloon\Helpers\Str;
 use Saloon\Helpers\Date;
+use Saloon\Http\Response;
 use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Exceptions\InvalidStateException;
 use Saloon\Http\Auth\AccessTokenAuthenticator;

--- a/tests/Feature/PoolTest.php
+++ b/tests/Feature/PoolTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Exception\ConnectException;

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Senders\GuzzleSender;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;

--- a/tests/Feature/SoloRequestTest.php
+++ b/tests/Feature/SoloRequestTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Responses\Response;
+use Saloon\Http\Response;
 use GuzzleHttp\Promise\PromiseInterface;
 use Saloon\Exceptions\Request\RequestException;
 use Saloon\Tests\Fixtures\Requests\SoloUserRequest;

--- a/tests/Fixtures/Connectors/CustomResponseConnector.php
+++ b/tests/Fixtures/Connectors/CustomResponseConnector.php
@@ -9,7 +9,7 @@ use Saloon\Tests\Fixtures\Responses\CustomResponse;
 
 class CustomResponseConnector extends Connector
 {
-    protected string $response = CustomResponse::class;
+    protected ?string $response = CustomResponse::class;
 
     /**
      * Define the base url of the api.

--- a/tests/Fixtures/Connectors/InvalidResponseConnector.php
+++ b/tests/Fixtures/Connectors/InvalidResponseConnector.php
@@ -9,7 +9,7 @@ use Saloon\Tests\Fixtures\Requests\InvalidResponseClass;
 
 class InvalidResponseConnector extends Connector
 {
-    protected string $response = InvalidResponseClass::class;
+    protected ?string $response = InvalidResponseClass::class;
 
     /**
      * Define the base url of the api.

--- a/tests/Fixtures/Data/User.php
+++ b/tests/Fixtures/Data/User.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Data;
 
-use Saloon\Http\Responses\Response;
+use Saloon\Http\Response;
 
 class User
 {

--- a/tests/Fixtures/Requests/InterceptedResponseRequest.php
+++ b/tests/Fixtures/Requests/InterceptedResponseRequest.php
@@ -6,7 +6,7 @@ namespace Saloon\Tests\Fixtures\Requests;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
-use Saloon\Http\Responses\Response;
+use Saloon\Http\Response;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
 
 class InterceptedResponseRequest extends Request

--- a/tests/Fixtures/Requests/InvalidResponseClass.php
+++ b/tests/Fixtures/Requests/InvalidResponseClass.php
@@ -23,7 +23,7 @@ class InvalidResponseClass extends Request
      *
      * @var string
      */
-    protected string $response = UserResponseNoExtendSaloonResponse::class;
+    protected ?string $response = UserResponseNoExtendSaloonResponse::class;
 
     /**
      * The connector.

--- a/tests/Fixtures/Requests/UserRequestWithCustomResponse.php
+++ b/tests/Fixtures/Requests/UserRequestWithCustomResponse.php
@@ -22,7 +22,7 @@ class UserRequestWithCustomResponse extends Request
      *
      * @var string
      */
-    protected string $response = UserResponse::class;
+    protected ?string $response = UserResponse::class;
 
     /**
      * Define the endpoint for the request.

--- a/tests/Fixtures/Responses/CustomResponse.php
+++ b/tests/Fixtures/Responses/CustomResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Responses;
 
-use Saloon\Http\Responses\Response;
+use Saloon\Http\Response;
 
 class CustomResponse extends Response
 {

--- a/tests/Fixtures/Responses/UserResponse.php
+++ b/tests/Fixtures/Responses/UserResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Responses;
 
-use Saloon\Http\Responses\Response;
+use Saloon\Http\Response;
 
 class UserResponse extends Response
 {

--- a/tests/Fixtures/Senders/ArraySender.php
+++ b/tests/Fixtures/Senders/ArraySender.php
@@ -31,8 +31,9 @@ class ArraySender implements Sender
      */
     public function sendRequest(PendingRequest $pendingRequest, bool $asynchronous = false): Response|PromiseInterface
     {
+        /** @var class-string<\Saloon\Contracts\Response> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
-        return new $responseClass($pendingRequest, new GuzzleResponse(200, ['X-Fake' => true], 'Default'));
+        return $responseClass::fromPsrResponse(new GuzzleResponse(200, ['X-Fake' => true], 'Default'), $pendingRequest);
     }
 }

--- a/tests/Fixtures/Senders/ArraySender.php
+++ b/tests/Fixtures/Senders/ArraySender.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Senders;
 
+use Saloon\Http\Response;
 use Saloon\Contracts\Sender;
-use Saloon\Http\Responses\Response;
 use Saloon\Contracts\PendingRequest;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;

--- a/tests/Fixtures/Senders/ArraySender.php
+++ b/tests/Fixtures/Senders/ArraySender.php
@@ -34,6 +34,6 @@ class ArraySender implements Sender
         /** @var class-string<\Saloon\Contracts\Response> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
-        return $responseClass::fromPsrResponse(new GuzzleResponse(200, ['X-Fake' => true], 'Default'), $pendingRequest);
+        return $responseClass::fromPsrResponse(new GuzzleResponse(200, ['X-Fake' => true], 'Default'), $pendingRequest, null);
     }
 }

--- a/tests/Unit/ConnectorTest.php
+++ b/tests/Unit/ConnectorTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Response;
 use GuzzleHttp\Promise\Promise;
 use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;

--- a/tests/Unit/MiddlewarePipelineTest.php
+++ b/tests/Unit/MiddlewarePipelineTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Helpers\MiddlewarePipeline;
 use Saloon\Tests\Fixtures\Requests\UserRequest;

--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use Saloon\Http\Request;
+use Saloon\Http\Response;
 use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;

--- a/tests/Unit/MockResponseTest.php
+++ b/tests/Unit/MockResponseTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
+use Saloon\Http\Response;
 use Saloon\Http\Faking\MockClient;
-use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Responses\UserData;
 use Saloon\Tests\Fixtures\Requests\UserRequest;


### PR DESCRIPTION
This PR simplifies Saloon's responses by removing the requirement for a sender to provide a response. I've also massively simplified the `resolveResponse` logic which before was quite a big method. 

Previously, you could only specify custom responses that extended the base one. You can still do that now, but it now supports your own implementation.