### PR TITLE
Fix | V2 - Changed the Response class return type to its interface counterpart

### DIFF
--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -434,7 +434,7 @@ class PendingRequest implements PendingRequestContract
      *
      * @return \Saloon\Contracts\Response
      */
-    public function send(): Response
+    public function send(): ResponseContract
     {
         return (new Dispatcher($this))->execute();
     }


### PR DESCRIPTION
I noticed (well.. PhpStorm did..) that the return type was referring to the class which was imported, rather than the interface, which is aliased.

So I changed the return type to use the interface.