### PR TITLE
Feature | V2 Allow other simulated responses to take priority

### DIFF
--- a/src/Contracts/MiddlewarePipeline.php
+++ b/src/Contracts/MiddlewarePipeline.php
@@ -11,20 +11,20 @@ interface MiddlewarePipeline
     /**
      * Add a middleware before the request is sent
      *
-     * @param callable $closure
+     * @param callable $callable
      * @param bool $prepend
      * @return $this
      */
-    public function onRequest(callable $closure, bool $prepend = false): static;
+    public function onRequest(callable $callable, bool $prepend = false): static;
 
     /**
      * Add a middleware after the request is sent
      *
-     * @param callable $closure
+     * @param callable $callable
      * @param bool $prepend
      * @return $this
      */
-    public function onResponse(callable $closure, bool $prepend = false): static;
+    public function onResponse(callable $callable, bool $prepend = false): static;
 
     /**
      * Process the request pipeline.

--- a/src/Contracts/PendingRequest.php
+++ b/src/Contracts/PendingRequest.php
@@ -232,4 +232,19 @@ interface PendingRequest
      * @return mixed
      */
     public function createDtoFromResponse(Response $response): mixed;
+
+    /**
+     * Set if the request is going to be sent asynchronously
+     *
+     * @param bool $asynchronous
+     * @return $this
+     */
+    public function setAsynchronous(bool $asynchronous): static;
+
+    /**
+     * Check if the request is asynchronous
+     *
+     * @return bool
+     */
+    public function isAsynchronous(): bool;
 }

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -37,14 +37,14 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
     /**
      * Add a middleware before the request is sent
      *
-     * @param callable $closure
+     * @param callable $callable
      * @param bool $prepend
      * @return $this
      */
-    public function onRequest(callable $closure, bool $prepend = false): static
+    public function onRequest(callable $callable, bool $prepend = false): static
     {
-        $this->requestPipeline = $this->requestPipeline->pipe(function (PendingRequest $pendingRequest) use ($closure) {
-            $result = $closure($pendingRequest);
+        $this->requestPipeline = $this->requestPipeline->pipe(function (PendingRequest $pendingRequest) use ($callable) {
+            $result = $callable($pendingRequest);
 
             if ($result instanceof PendingRequest) {
                 return $result;
@@ -63,14 +63,14 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
     /**
      * Add a middleware after the request is sent
      *
-     * @param callable $closure
+     * @param callable $callable
      * @param bool $prepend
      * @return $this
      */
-    public function onResponse(callable $closure, bool $prepend = false): static
+    public function onResponse(callable $callable, bool $prepend = false): static
     {
-        $this->responsePipeline = $this->responsePipeline->pipe(function (Response $response) use ($closure) {
-            $result = $closure($response);
+        $this->responsePipeline = $this->responsePipeline->pipe(function (Response $response) use ($callable) {
+            $result = $callable($response);
 
             return $result instanceof Response ? $result : $response;
         }, $prepend);

--- a/src/Http/Dispatcher.php
+++ b/src/Http/Dispatcher.php
@@ -16,9 +16,8 @@ class Dispatcher implements DispatcherContract
      * Constructor
      *
      * @param PendingRequest $pendingRequest
-     * @param bool $asynchronous
      */
-    public function __construct(protected PendingRequest $pendingRequest, protected bool $asynchronous = false)
+    public function __construct(protected PendingRequest $pendingRequest)
     {
         //
     }
@@ -37,7 +36,7 @@ class Dispatcher implements DispatcherContract
         // to create the SimulatedResponse and return that. Otherwise, we
         // will send a real request to the sender.
 
-        $response = $this->getSender()->sendRequest($pendingRequest, $this->asynchronous);
+        $response = $this->getSender()->sendRequest($pendingRequest, $pendingRequest->isAsynchronous());
 
         // Next we will need to run the response pipeline. If the response
         // is a Response we can run it directly, but if it is

--- a/src/Http/Middleware/DetermineMockResponse.php
+++ b/src/Http/Middleware/DetermineMockResponse.php
@@ -25,6 +25,10 @@ class DetermineMockResponse implements RequestMiddleware
             return $pendingRequest;
         }
 
+        if ($pendingRequest->hasSimulatedResponsePayload()) {
+            return $pendingRequest;
+        }
+
         $mockClient = $pendingRequest->getMockClient();
 
         // When we guess the next response from the MockClient it will

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -88,6 +88,13 @@ class PendingRequest implements PendingRequestContract
     protected ?SimulatedResponsePayload $simulatedResponsePayload = null;
 
     /**
+     * Determine if the pending request is asynchronous
+     *
+     * @var bool
+     */
+    protected bool $asynchronous = false;
+
+    /**
      * Build up the request payload.
      *
      * @param \Saloon\Contracts\Connector $connector
@@ -436,6 +443,8 @@ class PendingRequest implements PendingRequestContract
      */
     public function send(): ResponseContract
     {
+        $this->setAsynchronous(false);
+
         return (new Dispatcher($this))->execute();
     }
 
@@ -446,7 +455,9 @@ class PendingRequest implements PendingRequestContract
      */
     public function sendAsync(): PromiseInterface
     {
-        return (new Dispatcher($this, true))->execute();
+        $this->setAsynchronous(true);
+
+        return (new Dispatcher($this))->execute();
     }
 
     /**
@@ -458,5 +469,28 @@ class PendingRequest implements PendingRequestContract
     public function createDtoFromResponse(ResponseContract $response): mixed
     {
         return $this->request->createDtoFromResponse($response) ?? $this->connector->createDtoFromResponse($response);
+    }
+
+    /**
+     * Set if the request is going to be sent asynchronously
+     *
+     * @param bool $asynchronous
+     * @return PendingRequestContract
+     */
+    public function setAsynchronous(bool $asynchronous): static
+    {
+        $this->asynchronous = $asynchronous;
+
+        return $this;
+    }
+
+    /**
+     * Check if the request is asynchronous
+     *
+     * @return bool
+     */
+    public function isAsynchronous(): bool
+    {
+        return $this->asynchronous;
     }
 }

--- a/src/Http/Pool.php
+++ b/src/Http/Pool.php
@@ -141,8 +141,10 @@ class Pool implements PoolContract
      * Send the pool and create a Promise
      *
      * @return \GuzzleHttp\Promise\PromiseInterface
+     * @throws \ReflectionException
      * @throws \Saloon\Exceptions\InvalidPoolItemException
-     * @throws \Saloon\Exceptions\SaloonException
+     * @throws \Saloon\Exceptions\InvalidResponseClassException
+     * @throws \Saloon\Exceptions\PendingRequestException
      */
     public function send(): PromiseInterface
     {

--- a/tests/Feature/AsyncRequestTest.php
+++ b/tests/Feature/AsyncRequestTest.php
@@ -25,6 +25,7 @@ test('an asynchronous request can be made successfully', function () {
 
     $data = $response->json();
 
+    expect($response->getPendingRequest()->isAsynchronous())->toBeTrue();
     expect($response->isMocked())->toBeFalse();
     expect($response->status())->toEqual(200);
 

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -16,6 +16,7 @@ test('a request can be made successfully', function () {
 
     $data = $response->json();
 
+    expect($response->getPendingRequest()->isAsynchronous())->toBeFalse();
     expect($response)->toBeInstanceOf(Response::class);
     expect($response->isMocked())->toBeFalse();
     expect($response->status())->toEqual(200);

--- a/tests/Feature/SimulatedResponsePayloadTest.php
+++ b/tests/Feature/SimulatedResponsePayloadTest.php
@@ -1,10 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Http\Faking\SimulatedResponsePayload;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
-use Saloon\Tests\Fixtures\Requests\UserRequest;
 
 test('if a simulated response payload was provided before mock response it will take priority', function () {
     $mockClient = new MockClient([

--- a/tests/Feature/SimulatedResponsePayloadTest.php
+++ b/tests/Feature/SimulatedResponsePayloadTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\Faking\SimulatedResponsePayload;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
+
+test('if a simulated response payload was provided before mock response it will take priority', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sam'], 200, ['X-Greeting' => 'Howdy']),
+    ]);
+
+    $fakeResponse = new SimulatedResponsePayload(['name' => 'Gareth'], 201, ['X-Greeting' => 'Hello']);
+
+    $request = new UserRequest;
+    $request->middleware()->onRequest(fn () => $fakeResponse);
+
+    $response = TestConnector::make()->send($request, $mockClient);
+
+    expect($response->json())->toEqual(['name' => 'Gareth']);
+    expect($response->status())->toEqual(201);
+    expect($response->header('X-Greeting'))->toEqual('Hello');
+});


### PR DESCRIPTION
This PR makes a change to the `DetermineMockResponse` middleware. If another `SimulatedResponsePayload` has already been set on the PendingRequest, the MockClient will be ignored.