### PR TITLE
Feature | V2 Better Merging Pipeline

### DIFF
--- a/src/Contracts/Pipeline.php
+++ b/src/Contracts/Pipeline.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Saloon\Contracts;
+
+interface Pipeline
+{
+    /**
+     * Add a pipe to the pipeline
+     *
+     * @param callable $callable
+     * @param bool $prepend
+     * @param string|null $name
+     * @return \Saloon\Helpers\Pipeline
+     * @throws \Saloon\Exceptions\DuplicatePipeNameException
+     */
+    public function pipe(callable $callable, bool $prepend = false, ?string $name = null): static;
+
+    /**
+     * Process the pipeline.
+     *
+     * @param mixed $payload
+     * @return mixed
+     */
+    public function process(mixed $payload): mixed;
+
+    /**
+     * Set the pipes on the pipeline.
+     *
+     * @param array<\Saloon\Data\Pipe> $pipes
+     * @return $this
+     */
+    public function setPipes(array $pipes): static;
+
+    /**
+     * Get all the pipes in the pipeline
+     *
+     * @return array<\Saloon\Data\Pipe>
+     */
+    public function getPipes(): array;
+}

--- a/src/Contracts/Pipeline.php
+++ b/src/Contracts/Pipeline.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Saloon\Contracts;
 
 interface Pipeline

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -257,13 +257,6 @@ interface Response
     public function getSenderException(): ?Throwable;
 
     /**
-     * Get the raw response
-     *
-     * @return mixed
-     */
-    public function getRawResponse(): mixed;
-
-    /**
      * Get the body of the response.
      *
      * @return string

--- a/src/Data/Pipe.php
+++ b/src/Data/Pipe.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Saloon\Data;
+
+class Pipe
+{
+    /**
+     * Constructor
+     *
+     * @param callable $callable
+     * @param string|null $name
+     */
+    public function __construct(
+        readonly public mixed $callable,
+        readonly public ?string $name = null,
+    )
+    {
+        //
+    }
+}

--- a/src/Data/Pipe.php
+++ b/src/Data/Pipe.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Saloon\Data;
 
 class Pipe
@@ -13,8 +15,7 @@ class Pipe
     public function __construct(
         readonly public mixed $callable,
         readonly public ?string $name = null,
-    )
-    {
+    ) {
         //
     }
 }

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -7,6 +7,7 @@ namespace Saloon\Helpers;
 use Saloon\Contracts\Response;
 use Saloon\Contracts\PendingRequest;
 use Saloon\Contracts\SimulatedResponsePayload;
+use Saloon\Contracts\Pipeline as PipelineContract;
 use Saloon\Contracts\MiddlewarePipeline as MiddlewarePipelineContract;
 
 class MiddlewarePipeline implements MiddlewarePipelineContract
@@ -14,24 +15,24 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
     /**
      * Request Pipeline
      *
-     * @var Pipeline
+     * @var \Saloon\Contracts\Pipeline
      */
-    protected Pipeline $requestPipeline;
+    protected PipelineContract $requestPipeline;
 
     /**
      * Response Pipeline
      *
-     * @var Pipeline
+     * @var \Saloon\Contracts\Pipeline
      */
-    protected Pipeline $responsePipeline;
+    protected PipelineContract $responsePipeline;
 
     /**
      * Constructor
      */
     public function __construct()
     {
-        $this->requestPipeline = new Pipeline();
-        $this->responsePipeline = new Pipeline();
+        $this->requestPipeline = new Pipeline;
+        $this->responsePipeline = new Pipeline;
     }
 
     /**

--- a/src/Helpers/MockConfig.php
+++ b/src/Helpers/MockConfig.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Helpers;
 
-class MockConfig
+final class MockConfig
 {
     /**
      * Default fixture path

--- a/src/Helpers/Pipeline.php
+++ b/src/Helpers/Pipeline.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Saloon\Helpers;
 
-use Saloon\Contracts\Pipeline as PipelineContract;
 use Saloon\Data\Pipe;
 use Saloon\Exceptions\DuplicatePipeNameException;
+use Saloon\Contracts\Pipeline as PipelineContract;
 
 class Pipeline implements PipelineContract
 {
@@ -87,6 +87,6 @@ class Pipeline implements PipelineContract
      */
     protected function pipeExists(string $name): bool
     {
-        return ! empty(array_filter($this->pipes, static fn(Pipe $pipe) => $pipe->name === $name));
+        return ! empty(array_filter($this->pipes, static fn (Pipe $pipe) => $pipe->name === $name));
     }
 }

--- a/src/Helpers/Pipeline.php
+++ b/src/Helpers/Pipeline.php
@@ -95,6 +95,12 @@ class Pipeline implements PipelineContract
      */
     protected function pipeExists(string $name): bool
     {
-        return ! empty(array_filter($this->pipes, static fn (Pipe $pipe) => $pipe->name === $name));
+        foreach ($this->pipes as $pipe) {
+            if ($pipe->name === $name) {
+                return true;
+            }
+        }
+        
+        return false;
     }
 }

--- a/src/Helpers/Pipeline.php
+++ b/src/Helpers/Pipeline.php
@@ -59,12 +59,20 @@ class Pipeline implements PipelineContract
     /**
      * Set the pipes on the pipeline.
      *
-     * @param array<\Saloon\Data\Pipe> $pipes
+     * @param array $pipes
      * @return $this
+     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
     public function setPipes(array $pipes): static
     {
-        $this->pipes = $pipes;
+        $this->pipes = [];
+
+        // Loop through each of the pipes and manually add each pipe
+        // so we can check if the name already exists.
+
+        foreach ($pipes as $pipe) {
+            $this->pipe($pipe->callable, false, $pipe->name);
+        }
 
         return $this;
     }

--- a/src/Helpers/Storage.php
+++ b/src/Helpers/Storage.php
@@ -21,12 +21,14 @@ class Storage
      * Constructor
      *
      * @param string $baseDirectory
-     * @throws DirectoryNotFoundException
+     * @param bool $createMissingBaseDirectory
+     * @throws \Saloon\Exceptions\DirectoryNotFoundException
+     * @throws \Saloon\Exceptions\UnableToCreateDirectoryException
      */
-    public function __construct(string $baseDirectory)
+    public function __construct(string $baseDirectory, bool $createMissingBaseDirectory = false)
     {
         if (! is_dir($baseDirectory)) {
-            throw new DirectoryNotFoundException($baseDirectory);
+            $createMissingBaseDirectory ? $this->createDirectory($baseDirectory) : throw new DirectoryNotFoundException($baseDirectory);
         }
 
         $this->baseDirectory = $baseDirectory;
@@ -104,11 +106,7 @@ class Storage
         $directoryWithoutFilename = implode(DIRECTORY_SEPARATOR, explode(DIRECTORY_SEPARATOR, $fullPath, -1));
 
         if (empty($directoryWithoutFilename) === false && is_dir($directoryWithoutFilename) === false) {
-            $createdDirectory = mkdir($directoryWithoutFilename, 0777, true);
-
-            if ($createdDirectory === false && is_dir($directoryWithoutFilename) === false) {
-                throw new UnableToCreateDirectoryException($directoryWithoutFilename);
-            }
+            $this->createDirectory($directoryWithoutFilename);
         }
 
         $createdFile = file_put_contents($fullPath, $contents);
@@ -118,5 +116,23 @@ class Storage
         }
 
         return $this;
+    }
+
+    /**
+     * Create a directory
+     *
+     * @param string $directory
+     * @return bool
+     * @throws \Saloon\Exceptions\UnableToCreateDirectoryException
+     */
+    public function createDirectory(string $directory): bool
+    {
+        $createdDirectory = mkdir($directory, 0777, true);
+
+        if ($createdDirectory === false && is_dir($directory) === false) {
+            throw new UnableToCreateDirectoryException($directory);
+        }
+
+        return true;
     }
 }

--- a/src/Http/Faking/Fixture.php
+++ b/src/Http/Faking/Fixture.php
@@ -37,13 +37,14 @@ class Fixture
      * Constructor
      *
      * @param string $name
-     * @param Storage|null $storage
-     * @throws DirectoryNotFoundException
+     * @param \Saloon\Helpers\Storage|null $storage
+     * @throws \Saloon\Exceptions\DirectoryNotFoundException
+     * @throws \Saloon\Exceptions\UnableToCreateDirectoryException
      */
     public function __construct(string $name, Storage $storage = null)
     {
         $this->name = $name;
-        $this->storage = $storage ?? new Storage(MockConfig::getFixturePath());
+        $this->storage = $storage ?? new Storage(MockConfig::getFixturePath(), true);
     }
 
     /**

--- a/src/Http/Faking/Fixture.php
+++ b/src/Http/Faking/Fixture.php
@@ -8,7 +8,6 @@ use Saloon\Helpers\Storage;
 use Saloon\Helpers\MockConfig;
 use Saloon\Data\RecordedResponse;
 use Saloon\Exceptions\FixtureMissingException;
-use Saloon\Exceptions\DirectoryNotFoundException;
 
 class Fixture
 {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -88,16 +88,6 @@ class Response implements ResponseContract
     }
 
     /**
-     * Get the raw response
-     *
-     * @return mixed
-     */
-    public function getRawResponse(): mixed
-    {
-        return $this->psrResponse;
-    }
-
-    /**
      * Get the body of the response as string.
      *
      * @return string

--- a/tests/Unit/MiddlewarePipelineTest.php
+++ b/tests/Unit/MiddlewarePipelineTest.php
@@ -196,6 +196,19 @@ test('you can merge a middleware pipeline together', closure: function () {
     expect($pipelineA->getResponsePipeline()->getPipes())->toEqual($pipelineB->getResponsePipeline()->getPipes());
 });
 
+test('when merging a middleware pipeline together if two pipelines exist with the same pipe it throws an exception', function () {
+    $pipelineA = new MiddlewarePipeline;
+    $pipelineB = new MiddlewarePipeline;
+
+    $pipelineA->onRequest(fn () => null, false, 'howdy');
+    $pipelineB->onRequest(fn () => null, false, 'howdy');
+
+    $this->expectException(DuplicatePipeNameException::class);
+    $this->expectExceptionMessage('The "howdy" pipe already exists on the pipeline');
+
+    $pipelineA->merge($pipelineB);
+});
+
 test('a request pipeline is run in order of pipes', function () {
     $pipeline = new MiddlewarePipeline;
     $names = [];

--- a/tests/Unit/MiddlewarePipelineTest.php
+++ b/tests/Unit/MiddlewarePipelineTest.php
@@ -183,7 +183,7 @@ test('you can merge a middleware pipeline together', closure: function () {
         })
         ->onResponse(function (Response $response) {
             return $response->throw();
-        });
+        }, false, 'response');
 
     expect($pipelineB->getRequestPipeline()->getPipes())->toBeEmpty();
     expect($pipelineB->getResponsePipeline()->getPipes())->toBeEmpty();
@@ -192,6 +192,8 @@ test('you can merge a middleware pipeline together', closure: function () {
 
     expect($pipelineB->getRequestPipeline()->getPipes())->toHaveCount(2);
     expect($pipelineB->getResponsePipeline()->getPipes())->toHaveCount(1);
+    expect($pipelineA->getRequestPipeline()->getPipes())->toEqual($pipelineB->getRequestPipeline()->getPipes());
+    expect($pipelineA->getResponsePipeline()->getPipes())->toEqual($pipelineB->getResponsePipeline()->getPipes());
 });
 
 test('a request pipeline is run in order of pipes', function () {

--- a/tests/Unit/MockConfigTest.php
+++ b/tests/Unit/MockConfigTest.php
@@ -2,12 +2,17 @@
 
 declare(strict_types=1);
 
+use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use Saloon\Helpers\MockConfig;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Exceptions\FixtureMissingException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
-use Saloon\Exceptions\DirectoryNotFoundException;
+
+afterEach(function () {
+    MockConfig::setFixturePath('tests/Fixtures/Saloon');
+});
 
 test('you can change the default fixture path', function () {
     expect(MockConfig::getFixturePath())->toEqual('tests/Fixtures/Saloon');
@@ -16,14 +21,6 @@ test('you can change the default fixture path', function () {
 
     expect(MockConfig::getFixturePath())->toEqual('saloon-requests/responses');
 });
-
-test('if the fixture path is invalid it will throw an exception', function () {
-    MockConfig::setFixturePath('saloon-requests/responses');
-
-    new MockClient([
-        MockResponse::fixture('example'),
-    ]);
-})->throws(DirectoryNotFoundException::class, 'The directory "saloon-requests/responses" does not exist or is not a valid directory.');
 
 test('you can throw an exception if the fixture does not exist', function () {
     MockConfig::setFixturePath('tests/Fixtures/Saloon');
@@ -38,3 +35,18 @@ test('you can throw an exception if the fixture does not exist', function () {
 
     connector()->send(new UserRequest, $mockClient);
 })->throws(FixtureMissingException::class, 'The fixture "example.json" could not be found in storage.');
+
+test('if the default fixture path doesnt exist it will be created', function () {
+    $filesystem = new Filesystem(new LocalFilesystemAdapter('tests/Fixtures'));
+    $filesystem->deleteDirectory('OtherFixturePath');
+
+    MockConfig::setFixturePath('tests/Fixtures/OtherFixturePath');
+
+    expect($filesystem->has('OtherFixturePath'))->toBeFalse();
+
+    new MockClient([
+        MockResponse::fixture('example'),
+    ]);
+
+    expect($filesystem->has('OtherFixturePath'))->toBeTrue();
+});

--- a/tests/Unit/MockConfigTest.php
+++ b/tests/Unit/MockConfigTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-use League\Flysystem\Filesystem;
-use League\Flysystem\Local\LocalFilesystemAdapter;
 use Saloon\Helpers\MockConfig;
+use League\Flysystem\Filesystem;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Exceptions\FixtureMissingException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 
 afterEach(function () {
     MockConfig::setFixturePath('tests/Fixtures/Saloon');


### PR DESCRIPTION
This PR makes some more improvements to the middleware pipelines, specifically switching to a `Pipe` class for each pipe which now contains the name. This means I no longer need a separate array for the pipe names and when merging pipelines, all the names can be brought across. 

The default fixture directory will now be created even when it doesn't exist. @simple-hacker @Gummibeer 

Todo: Throw an exception if merging results in two of the same middleware?