### PR TITLE
Feature | V2 Iterable type hints

### DIFF
--- a/src/Contracts/ArrayStore.php
+++ b/src/Contracts/ArrayStore.php
@@ -9,7 +9,7 @@ interface ArrayStore
     /**
      * Retrieve all the items.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function all(): array;
 
@@ -25,7 +25,7 @@ interface ArrayStore
     /**
      * Overwrite the entire repository's contents.
      *
-     * @param array $data
+     * @param array<string, mixed> $data
      * @return $this
      */
     public function set(array $data): static;
@@ -33,7 +33,7 @@ interface ArrayStore
     /**
      * Merge in other arrays.
      *
-     * @param array ...$arrays
+     * @param array<string, mixed> ...$arrays
      * @return $this
      */
     public function merge(array ...$arrays): static;

--- a/src/Contracts/Arrayable.php
+++ b/src/Contracts/Arrayable.php
@@ -9,7 +9,7 @@ interface Arrayable
     /**
      * Convert the instance to an array
      *
-     * @return array
+     * @return array<array-key, mixed>
      */
     public function toArray(): array;
 }

--- a/src/Contracts/Connector.php
+++ b/src/Contracts/Connector.php
@@ -41,7 +41,7 @@ interface Connector extends Authenticatable, CanThrowRequestExceptions, Conditio
     /**
      * Create a request pool
      *
-     * @param iterable|callable $requests
+     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>|callable $requests
      * @param int|callable $concurrency
      * @param callable|null $responseHandler
      * @param callable|null $exceptionHandler

--- a/src/Contracts/Pool.php
+++ b/src/Contracts/Pool.php
@@ -36,7 +36,7 @@ interface Pool
     /**
      * Set the requests
      *
-     * @param iterable|callable $requests
+     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>|callable $requests
      * @return $this
      */
     public function setRequests(iterable|callable $requests): static;
@@ -44,7 +44,7 @@ interface Pool
     /**
      * Get the request generator
      *
-     * @return \Generator
+     * @return \Generator<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
      */
     public function getRequests(): Generator;
 

--- a/src/Contracts/Pool.php
+++ b/src/Contracts/Pool.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Saloon\Contracts;
 
-use Generator;
 use GuzzleHttp\Promise\PromiseInterface;
 
 interface Pool
@@ -44,9 +43,9 @@ interface Pool
     /**
      * Get the request generator
      *
-     * @return \Generator<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
+     * @return iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
      */
-    public function getRequests(): Generator;
+    public function getRequests(): iterable;
 
     /**
      * Send the pool and create a Promise

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -61,7 +61,7 @@ interface Response extends HasHeaders
      * Get a header from the response.
      *
      * @param string $header
-     * @return string|array|null
+     * @return string|array<array-key, mixed>|null
      */
     public function header(string $header): string|array|null;
 
@@ -107,7 +107,7 @@ interface Response extends HasHeaders
      * Get the JSON decoded body of the response as a collection.
      *
      * @param array-key|null $key
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<array-key, mixed>
      */
     public function collect(string|int|null $key = null): Collection;
 

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -82,11 +82,11 @@ interface Response extends HasHeaders
     /**
      * Get the JSON decoded body of the response as an array or scalar value.
      *
-     * @param string|null $key
-     * @param mixed $default
-     * @return mixed
+     * @param array-key|null $key
+     * @param mixed|null $default
+     * @return ($key is null ? array<array-key, mixed> : mixed)
      */
-    public function json(string $key = null, mixed $default = null): mixed;
+    public function json(string|int|null $key = null, mixed $default = null): mixed;
 
     /**
      * Get the JSON decoded body of the response as an object.

--- a/src/Data/MultipartValue.php
+++ b/src/Data/MultipartValue.php
@@ -16,7 +16,7 @@ class MultipartValue implements Arrayable
      * @param string $name
      * @param \Psr\Http\Message\StreamInterface|resource|string|int $value
      * @param string|null $filename
-     * @param array $headers
+     * @param array<string, mixed> $headers
      */
     public function __construct(
         public string  $name,
@@ -32,7 +32,12 @@ class MultipartValue implements Arrayable
     /**
      * Convert the instance to an array
      *
-     * @return array
+     * @return array{
+     *     name: string,
+     *     contents: mixed,
+     *     filename: string|null,
+     *     headers: array<string, mixed>,
+     * }
      */
     public function toArray(): array
     {

--- a/src/Data/RecordedResponse.php
+++ b/src/Data/RecordedResponse.php
@@ -14,7 +14,7 @@ class RecordedResponse implements JsonSerializable
      * Constructor
      *
      * @param int $statusCode
-     * @param array $headers
+     * @param array<string, mixed> $headers
      * @param mixed $data
      */
     public function __construct(
@@ -34,6 +34,13 @@ class RecordedResponse implements JsonSerializable
      */
     public static function fromFile(string $contents): static
     {
+        /**
+         * @param array{
+         *     statusCode: int,
+         *     headers: array<string, mixed>,
+         *     data: mixed,
+         * } $fileData
+         */
         $fileData = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
 
         return new static(
@@ -82,7 +89,11 @@ class RecordedResponse implements JsonSerializable
     /**
      * Define the JSON object if this class is converted into JSON
      *
-     * @return array
+     * @return array{
+     *     statusCode: int,
+     *     headers: array<string, mixed>,
+     *     data: mixed,
+     * }
      */
     public function jsonSerialize(): array
     {

--- a/src/Helpers/Arr.php
+++ b/src/Helpers/Arr.php
@@ -13,6 +13,8 @@ class Arr
      *
      * @param mixed $value
      * @return bool
+     *
+     * @phpstan-assert-if-true array|ArrayAccess $value
      */
     public static function accessible(mixed $value): bool
     {
@@ -22,7 +24,7 @@ class Arr
     /**
      * Determine if the given key exists in the provided array.
      *
-     * @param array $array
+     * @param array<array-key, mixed> $array
      * @param array-key|float $key
      * @return bool
      */
@@ -38,10 +40,10 @@ class Arr
     /**
      * Get an item from an array using "dot" notation.
      *
-     * @param array $array
+     * @param array<array-key, mixed> $array
      * @param array-key|null $key
      * @param mixed|null $default
-     * @return mixed
+     * @return ($key is null ? array<array-key, mixed> : mixed)
      */
     public static function get(array $array, string|int|null $key, mixed $default = null): mixed
     {
@@ -75,9 +77,14 @@ class Arr
     /**
      * Map an array with keys
      *
-     * @param array $items
-     * @param callable $callback
-     * @return array
+     * @template TKey of array-key
+     * @template TValue
+     * @template TReturnKey of array-key
+     * @template TReturnValue
+     *
+     * @param array<TKey, TValue> $items
+     * @param callable(TValue, TKey): array<TReturnKey, TReturnValue> $callback
+     * @return array<TReturnKey, TReturnValue>
      */
     public static function mapWithKeys(array $items, callable $callback): array
     {

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -11,8 +11,8 @@ class Helpers
     /**
      * Returns all traits used by a class, its parent classes and trait of their traits.
      *
-     * @param object|string $class
-     * @return array
+     * @param object|class-string $class
+     * @return array<class-string, class-string>
      */
     public static function classUsesRecursive(object|string $class): array
     {
@@ -32,8 +32,8 @@ class Helpers
     /**
      * Returns all traits used by a trait and its traits.
      *
-     * @param string $trait
-     * @return array
+     * @param class-string $trait
+     * @return array<class-string, class-string>
      */
     public static function traitUsesRecursive(string $trait): array
     {
@@ -49,7 +49,7 @@ class Helpers
     /**
      * Get the class "basename" of the given object / class.
      *
-     * @param object|string $class
+     * @param object|class-string $class
      * @return string
      */
     public static function classBasename(object|string $class): string

--- a/src/Helpers/OAuth2/OAuthConfig.php
+++ b/src/Helpers/OAuth2/OAuthConfig.php
@@ -60,7 +60,7 @@ class OAuthConfig implements MakeableContract
     /**
      * The default scopes that will be applied to every authorization URL.
      *
-     * @var array
+     * @var array<string>
      */
     protected array $defaultScopes = [];
 
@@ -205,7 +205,7 @@ class OAuthConfig implements MakeableContract
     /**
      * Get the default scopes.
      *
-     * @return array
+     * @return array<string>
      */
     public function getDefaultScopes(): array
     {
@@ -215,7 +215,7 @@ class OAuthConfig implements MakeableContract
     /**
      * Set the default scopes.
      *
-     * @param array $defaultScopes
+     * @param array<string> $defaultScopes
      * @return $this
      */
     public function setDefaultScopes(array $defaultScopes): static

--- a/src/Helpers/Pipeline.php
+++ b/src/Helpers/Pipeline.php
@@ -59,7 +59,7 @@ class Pipeline implements PipelineContract
     /**
      * Set the pipes on the pipeline.
      *
-     * @param array $pipes
+     * @param array<\Saloon\Data\Pipe> $pipes
      * @return $this
      * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
@@ -100,7 +100,7 @@ class Pipeline implements PipelineContract
                 return true;
             }
         }
-        
+
         return false;
     }
 }

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -9,7 +9,7 @@ class Str
     /**
      * Determine if a given string matches a given pattern.
      *
-     * @param string|iterable $pattern
+     * @param string|iterable<string> $pattern
      * @param string $value
      * @return bool
      */
@@ -62,7 +62,7 @@ class Str
      * Determine if a given string ends with a given substring.
      *
      * @param string $haystack
-     * @param string|iterable $needles
+     * @param string|iterable<string> $needles
      * @return bool
      */
     public static function endsWith(string $haystack, string|iterable $needles): bool

--- a/src/Http/Faking/SimulatedResponsePayload.php
+++ b/src/Http/Faking/SimulatedResponsePayload.php
@@ -52,9 +52,9 @@ class SimulatedResponsePayload implements SimulatedResponsePayloadContract
     /**
      * Create a new mock response
      *
-     * @param array|string $body
+     * @param array<string, mixed>|string $body
      * @param int $status
-     * @param array $headers
+     * @param array<string, mixed> $headers
      */
     public function __construct(array|string $body = [], int $status = 200, array $headers = [])
     {

--- a/src/Http/OAuth2/GetAccessTokenRequest.php
+++ b/src/Http/OAuth2/GetAccessTokenRequest.php
@@ -47,7 +47,13 @@ class GetAccessTokenRequest extends Request implements HasBody
     /**
      * Register the default data.
      *
-     * @return array
+     * @return array{
+     *     grant_type: string,
+     *     code: string,
+     *     client_id: string,
+     *     client_secret: string,
+     *     redirect_uri: string,
+     * }
      */
     public function defaultBody(): array
     {

--- a/src/Http/OAuth2/GetRefreshTokenRequest.php
+++ b/src/Http/OAuth2/GetRefreshTokenRequest.php
@@ -47,7 +47,12 @@ class GetRefreshTokenRequest extends Request implements HasBody
     /**
      * Register the default data.
      *
-     * @return array
+     * @return array{
+     *     grant_type: string,
+     *     refresh_token: string,
+     *     client_id: string,
+     *     client_secret: string,
+     * }
      */
     public function defaultBody(): array
     {

--- a/src/Http/Pool.php
+++ b/src/Http/Pool.php
@@ -17,7 +17,7 @@ class Pool implements PoolContract
     /**
      * Requests inside the pool
      *
-     * @var \Generator
+     * @var \Generator<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
      */
     protected Generator $requests;
 
@@ -49,13 +49,13 @@ class Pool implements PoolContract
      *
      * @var \Closure|int
      */
-    protected \Closure|int $concurrency;
+    protected Closure|int $concurrency;
 
     /**
      * Constructor
      *
      * @param \Saloon\Http\Connector $connector
-     * @param iterable|callable $requests
+     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>|callable $requests
      * @param int|callable $concurrency
      * @param callable|null $responseHandler
      * @param callable|null $exceptionHandler
@@ -111,7 +111,7 @@ class Pool implements PoolContract
     /**
      * Set the requests
      *
-     * @param iterable|callable $requests
+     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>|callable $requests
      * @return $this
      */
     public function setRequests(iterable|callable $requests): static
@@ -132,7 +132,7 @@ class Pool implements PoolContract
     /**
      * Get the request generator
      *
-     * @return \Generator
+     * @return \Generator<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
      */
     public function getRequests(): Generator
     {

--- a/src/Http/Pool.php
+++ b/src/Http/Pool.php
@@ -17,9 +17,9 @@ class Pool implements PoolContract
     /**
      * Requests inside the pool
      *
-     * @var \Generator<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
+     * @var iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
      */
-    protected Generator $requests;
+    protected iterable $requests;
 
     /**
      * Handle Response Callback
@@ -132,9 +132,9 @@ class Pool implements PoolContract
     /**
      * Get the request generator
      *
-     * @return \Generator<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
+     * @return iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>
      */
-    public function getRequests(): Generator
+    public function getRequests(): iterable
     {
         return $this->requests;
     }

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -154,7 +154,7 @@ class GuzzleSender implements Sender
      * Build up all the request options
      *
      * @param \Saloon\Contracts\PendingRequest $pendingRequest
-     * @return array
+     * @return array<RequestOptions::*, mixed>
      */
     protected function createRequestOptions(PendingRequest $pendingRequest): array
     {

--- a/src/Repositories/ArrayStore.php
+++ b/src/Repositories/ArrayStore.php
@@ -15,14 +15,14 @@ class ArrayStore implements ArrayStoreContract
     /**
      * The repository's store
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected array $data = [];
 
     /**
      * Constructor
      *
-     * @param array $data
+     * @param array<string, mixed> $data
      */
     public function __construct(array $data = [])
     {
@@ -32,7 +32,7 @@ class ArrayStore implements ArrayStoreContract
     /**
      * Retrieve all the items.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function all(): array
     {
@@ -54,7 +54,7 @@ class ArrayStore implements ArrayStoreContract
     /**
      * Overwrite the entire repository.
      *
-     * @param array $data
+     * @param array<string, mixed> $data
      * @return $this
      */
     public function set(array $data): static
@@ -67,7 +67,7 @@ class ArrayStore implements ArrayStoreContract
     /**
      * Merge in other arrays.
      *
-     * @param array ...$arrays
+     * @param array<string, mixed> ...$arrays
      * @return $this
      */
     public function merge(array ...$arrays): static
@@ -108,6 +108,8 @@ class ArrayStore implements ArrayStoreContract
      * Determine if the store is empty
      *
      * @return bool
+     *
+     * @phpstan-assert-if-false non-empty-array $this->data
      */
     public function isEmpty(): bool
     {
@@ -118,6 +120,8 @@ class ArrayStore implements ArrayStoreContract
      * Determine if the store is not empty
      *
      * @return bool
+     *
+     * @phpstan-assert-if-true non-empty-array $this->data
      */
     public function isNotEmpty(): bool
     {

--- a/src/Repositories/Body/ArrayBodyRepository.php
+++ b/src/Repositories/Body/ArrayBodyRepository.php
@@ -16,14 +16,14 @@ class ArrayBodyRepository implements BodyRepository
     /**
      * Repository Data
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected array $data = [];
 
     /**
      * Constructor
      *
-     * @param array $value
+     * @param array<string, mixed> $value
      */
     public function __construct(mixed $value = [])
     {
@@ -33,7 +33,7 @@ class ArrayBodyRepository implements BodyRepository
     /**
      * Set a value inside the repository
      *
-     * @param array $value
+     * @param array<string, mixed> $value
      * @return $this
      */
     public function set(mixed $value): static
@@ -50,7 +50,7 @@ class ArrayBodyRepository implements BodyRepository
     /**
      * Merge another array into the repository
      *
-     * @param array ...$arrays
+     * @param array<string, mixed> ...$arrays
      * @return $this
      */
     public function merge(array ...$arrays): static
@@ -81,7 +81,7 @@ class ArrayBodyRepository implements BodyRepository
      *
      * @param array-key|null $key
      * @param mixed|null $default
-     * @return mixed
+     * @return ($key is null ? array<string, mixed> : mixed)
      */
     public function get(string|int|null $key = null, mixed $default = null): mixed
     {
@@ -108,7 +108,7 @@ class ArrayBodyRepository implements BodyRepository
     /**
      * Retrieve all in the repository
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function all(): array
     {
@@ -119,6 +119,8 @@ class ArrayBodyRepository implements BodyRepository
      * Determine if the repository is empty
      *
      * @return bool
+     *
+     * @phpstan-assert-if-false non-empty-array $this->data
      */
     public function isEmpty(): bool
     {
@@ -129,6 +131,8 @@ class ArrayBodyRepository implements BodyRepository
      * Determine if the repository is not empty
      *
      * @return bool
+     *
+     * @phpstan-assert-if-true non-empty-array $this->data
      */
     public function isNotEmpty(): bool
     {

--- a/src/Repositories/Body/ArrayBodyRepository.php
+++ b/src/Repositories/Body/ArrayBodyRepository.php
@@ -25,7 +25,7 @@ class ArrayBodyRepository implements BodyRepository
      *
      * @param array<string, mixed> $value
      */
-    public function __construct(mixed $value = [])
+    public function __construct(array $value = [])
     {
         $this->set($value);
     }

--- a/src/Repositories/Body/MultipartBodyRepository.php
+++ b/src/Repositories/Body/MultipartBodyRepository.php
@@ -76,7 +76,7 @@ class MultipartBodyRepository implements BodyRepository, Arrayable
      * @param string $name
      * @param \Psr\Http\Message\StreamInterface|resource|string $contents
      * @param string|null $filename
-     * @param array $headers
+     * @param array<string, mixed> $headers
      * @return $this
      */
     public function add(string $name, mixed $contents, string $filename = null, array $headers = []): static
@@ -170,7 +170,12 @@ class MultipartBodyRepository implements BodyRepository, Arrayable
      *
      * Converts all the multipart value objects into arrays.
      *
-     * @return array
+     * @return array<array{
+     *     name: string,
+     *     contents: mixed,
+     *     filename: string|null,
+     *     headers: array<string, mixed>,
+     * }>
      */
     public function toArray(): array
     {
@@ -180,12 +185,12 @@ class MultipartBodyRepository implements BodyRepository, Arrayable
     /**
      * Parse a multipart array
      *
-     * @param array $value
+     * @param array<string, mixed> $value
      * @return array<\Saloon\Data\MultipartValue>
      */
     protected function parseMultipartArray(array $value): array
     {
-        $multipartValues = array_filter($value, static fn (mixed $item) => $item instanceof MultipartValue);
+        $multipartValues = array_filter($value, static fn (mixed $item): bool => $item instanceof MultipartValue);
 
         if (count($value) !== count($multipartValues)) {
             throw new InvalidArgumentException(sprintf('The value array must only contain %s objects.', MultipartValue::class));

--- a/src/Traits/Body/HasFormBody.php
+++ b/src/Traits/Body/HasFormBody.php
@@ -42,7 +42,7 @@ trait HasFormBody
     /**
      * Default body
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function defaultBody(): array
     {

--- a/src/Traits/Body/HasJsonBody.php
+++ b/src/Traits/Body/HasJsonBody.php
@@ -42,7 +42,7 @@ trait HasJsonBody
     /**
      * Default body
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function defaultBody(): array
     {

--- a/src/Traits/Body/HasMultipartBody.php
+++ b/src/Traits/Body/HasMultipartBody.php
@@ -30,7 +30,7 @@ trait HasMultipartBody
     /**
      * Default body
      *
-     * @return array
+     * @return array<\Saloon\Data\MultipartValue>
      */
     protected function defaultBody(): array
     {

--- a/src/Traits/Connector/HasPool.php
+++ b/src/Traits/Connector/HasPool.php
@@ -12,7 +12,7 @@ trait HasPool
     /**
      * Create a request pool
      *
-     * @param iterable|callable $requests
+     * @param iterable<\GuzzleHttp\Promise\PromiseInterface|\Saloon\Contracts\Request>|callable $requests
      * @param int|callable $concurrency
      * @param callable|null $responseHandler
      * @param callable|null $exceptionHandler

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -56,7 +56,7 @@ trait AuthorizationCodeGrant
     /**
      * Get the Authorization URL.
      *
-     * @param array $scopes
+     * @param array<string> $scopes
      * @param string|null $state
      * @param string $scopeSeparator
      * @return string

--- a/src/Traits/RequestProperties/HasConfig.php
+++ b/src/Traits/RequestProperties/HasConfig.php
@@ -29,7 +29,7 @@ trait HasConfig
     /**
      * Default Config
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function defaultConfig(): array
     {

--- a/src/Traits/RequestProperties/HasHeaders.php
+++ b/src/Traits/RequestProperties/HasHeaders.php
@@ -29,7 +29,7 @@ trait HasHeaders
     /**
      * Default Request Headers
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function defaultHeaders(): array
     {

--- a/src/Traits/RequestProperties/HasQuery.php
+++ b/src/Traits/RequestProperties/HasQuery.php
@@ -29,7 +29,7 @@ trait HasQuery
     /**
      * Default Query Parameters
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function defaultQuery(): array
     {

--- a/src/Traits/Responses/HasResponseHelpers.php
+++ b/src/Traits/Responses/HasResponseHelpers.php
@@ -55,12 +55,12 @@ trait HasResponseHelpers
     /**
      * Get the JSON decoded body of the response as an array or scalar value.
      *
-     * @param string|null $key
+     * @param array-key|null $key
      * @param mixed|null $default
      * @return ($key is null ? array<array-key, mixed> : mixed)
      * @throws \JsonException
      */
-    public function json(string|null $key = null, mixed $default = null): mixed
+    public function json(string|int|null $key = null, mixed $default = null): mixed
     {
         if (! isset($this->decodedJson)) {
             $this->decodedJson = json_decode($this->body(), true, 512, JSON_THROW_ON_ERROR);

--- a/src/Traits/Responses/HasResponseHelpers.php
+++ b/src/Traits/Responses/HasResponseHelpers.php
@@ -20,7 +20,7 @@ trait HasResponseHelpers
     /**
      * The decoded JSON response.
      *
-     * @var array
+     * @var array<array-key, mixed>
      */
     protected array $decodedJson;
 
@@ -56,11 +56,11 @@ trait HasResponseHelpers
      * Get the JSON decoded body of the response as an array or scalar value.
      *
      * @param string|null $key
-     * @param mixed $default
-     * @return mixed
+     * @param mixed|null $default
+     * @return ($key is null ? array<array-key, mixed> : mixed)
      * @throws \JsonException
      */
-    public function json(string $key = null, mixed $default = null): mixed
+    public function json(string|null $key = null, mixed $default = null): mixed
     {
         if (! isset($this->decodedJson)) {
             $this->decodedJson = json_decode($this->body(), true, 512, JSON_THROW_ON_ERROR);
@@ -106,12 +106,22 @@ trait HasResponseHelpers
      * @see https://github.com/illuminate/collections
      *
      * @param array-key|null $key
-     * @return \Illuminate\Support\Collection
+     * @return \Illuminate\Support\Collection<array-key, mixed>
      * @throws \JsonException
      */
     public function collect(string|int|null $key = null): Collection
     {
-        return Collection::make($this->json($key));
+        $data = $this->json($key);
+
+        if (is_null($data)) {
+            return Collection::empty();
+        }
+
+        if (is_array($data)) {
+            return Collection::make($data);
+        }
+
+        return Collection::make([$data]);
     }
 
     /**
@@ -291,7 +301,7 @@ trait HasResponseHelpers
      * Get a header from the response.
      *
      * @param string $header
-     * @return string|array|null
+     * @return string|array<array-key, mixed>|null
      */
     public function header(string $header): string|array|null
     {

--- a/src/Traits/Responses/HasSimulationMethods.php
+++ b/src/Traits/Responses/HasSimulationMethods.php
@@ -42,7 +42,7 @@ trait HasSimulationMethods
      * Set if a response has been cached or not.
      *
      * @param bool $value
-     * @return mixed
+     * @return $this
      */
     public function setCached(bool $value): static
     {
@@ -55,7 +55,7 @@ trait HasSimulationMethods
      * Set if a response has been mocked or not.
      *
      * @param bool $value
-     * @return mixed
+     * @return $this
      */
     public function setMocked(bool $value): static
     {
@@ -68,7 +68,7 @@ trait HasSimulationMethods
      * Set the simulated response payload if the response was simulated.
      *
      * @param \Saloon\Contracts\SimulatedResponsePayload $simulatedResponsePayload
-     * @return mixed
+     * @return $this
      */
     public function setSimulatedResponsePayload(SimulatedResponsePayload $simulatedResponsePayload): static
     {

--- a/tests/Unit/Body/ArrayBodyRepositoryTest.php
+++ b/tests/Unit/Body/ArrayBodyRepositoryTest.php
@@ -23,18 +23,19 @@ test('the store can have an array provided', function () {
 });
 
 test('you can set it', function () {
-    $this->expectException(InvalidArgumentException::class);
-    $this->expectDeprecationMessage('The value must be an array');
-
-    new ArrayBodyRepository('Sam');
-});
-
-test('it will throw an exception if you set a non-array', function () {
     $body = new ArrayBodyRepository();
 
     $body->set(['name' => 'Sam']);
 
     expect($body->all())->toEqual(['name' => 'Sam']);
+});
+
+test('it will throw an exception if you set a non-array', function () {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectDeprecationMessage('The value must be an array');
+
+    $body = new ArrayBodyRepository();
+    $body->set('Sam');
 });
 
 test('you can add an item', function () {

--- a/tests/Unit/Body/MultipartBodyRepositoryTest.php
+++ b/tests/Unit/Body/MultipartBodyRepositoryTest.php
@@ -27,8 +27,8 @@ test('the store will throw an exception if set value is not an array', function 
     $this->expectException(InvalidArgumentException::class);
     $this->expectDeprecationMessage('The value must be an array');
 
-    $repository = new MultipartBodyRepository([]);
-    $repository->set('123');
+    $body = new MultipartBodyRepository();
+    $body->set('123');
 });
 
 test('the store will throw an exception if the array does not contain multipart values', function () {


### PR DESCRIPTION
I've added type hints to all iterables, except for
* src/Contracts/MockClient.php
* src/Http/Faking/MockClient.php
* src/Traits/Macroable.php

All three has tricky types, so doing them last when everything else is completed.

I also changed the constructor on ArrayBodyRepository to use an array directly instead of mixed, as it's not bound to mixed.
As part of that I also adjusted its test that tests if it correctly throws an Exception if the input is not an array.
I noticed that two of the tests had their labels mixed up (but the actual tests were correct).
So I also switched the tests content, to match their test label.

I also widened the `Response::json()` method to accept int, and not only string|null.
This is the same type that `Response::collect()` has, as well.
I also know that some APIs will return a collection of items, without being wrapped.
That way you can grab an item at a specific index directly, if you need to.

I've also widened the Generator type to iterable in the Pool.
We weren't using the benefit of a Generator, and were entirely using the iterable feature of it.
Do note that `Pool::getRequests()` return type was also changed, as part of that.
Should a Generator still be needed, it's easily sortable by manually yielding the iterable.

PHPStan now passes on level 6, except from my currently ignored local files (same as the initial list above).
All tests still also pass.