### PR TITLE
Fix | Authenticate a PendingRequest after being constructed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
         "pestphp/pest": "^1.21",
         "phpstan/phpstan": "^1.9",
         "spatie/ray": "^1.33",
-        "symfony/dom-crawler": "^6.0",
-        "symfony/stopwatch": "^6.2"
+        "symfony/dom-crawler": "^6.0"
     },
     "suggest": {
         "illuminate/collections": "Required for the response collect() method.",

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Saloon\Http;
 
-use Saloon\Contracts\Authenticator;
 use Saloon\Enums\Method;
 use Saloon\Helpers\Config;
 use Saloon\Helpers\Helpers;
@@ -17,6 +16,7 @@ use Saloon\Helpers\PluginHelper;
 use Saloon\Traits\Conditionable;
 use Saloon\Traits\HasMockClient;
 use Saloon\Contracts\Body\HasBody;
+use Saloon\Contracts\Authenticator;
 use Saloon\Helpers\ReflectionHelper;
 use GuzzleHttp\Promise\PromiseInterface;
 use Saloon\Contracts\Body\BodyRepository;

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Http;
 
+use Saloon\Contracts\Authenticator;
 use Saloon\Enums\Method;
 use Saloon\Helpers\Config;
 use Saloon\Helpers\Helpers;
@@ -94,6 +95,13 @@ class PendingRequest implements PendingRequestContract
     protected bool $asynchronous = false;
 
     /**
+     * Determines if the PendingRequest is ready to be sent
+     *
+     * @var bool
+     */
+    protected bool $ready = false;
+
+    /**
      * Build up the request payload.
      *
      * @param \Saloon\Contracts\Connector $connector
@@ -134,10 +142,14 @@ class PendingRequest implements PendingRequestContract
 
         $this->registerDefaultMiddleware();
 
-        // Finally, we will execute the request middleware pipeline which will
+        // Next, we will execute the request middleware pipeline which will
         // process any middleware added on the connector or the request.
 
         $this->executeRequestPipeline();
+
+        // Finally, we'll mark our PendingRequest as ready.
+
+        $this->ready = true;
     }
 
     /**
@@ -503,5 +515,27 @@ class PendingRequest implements PendingRequestContract
     public function isAsynchronous(): bool
     {
         return $this->asynchronous;
+    }
+
+    /**
+     * Authenticate the PendingRequest
+     *
+     * @param \Saloon\Contracts\Authenticator $authenticator
+     * @return $this
+     */
+    public function authenticate(Authenticator $authenticator): static
+    {
+        $this->authenticator = $authenticator;
+
+        // If the PendingRequest has already been constructed, it would be nice
+        // for someone to be able to run the "authenticate" method after. This
+        // will allow us to do this. With future versions of Saloon we will
+        // likely remove this method.
+
+        if ($this->ready === true) {
+            $this->authenticator->set($this);
+        }
+
+        return $this;
     }
 }

--- a/tests/Feature/RetryRequestTest.php
+++ b/tests/Feature/RetryRequestTest.php
@@ -99,17 +99,14 @@ test('a failed request can have an interval between each attempt', function () {
     $connector = new TestConnector;
     $connector->withMockClient($mockClient);
 
-    $stopwatch = new Stopwatch();
-    $stopwatch->start('sendAndRetry');
+    $start = microtime(true);
 
     $connector->sendAndRetry(new UserRequest, 3, 1000);
-
-    $duration = $stopwatch->stop('sendAndRetry')->getDuration();
 
     // It should be a duration of 2000ms (2 seconds) because the there are two requests
     // after the first.
 
-    expect(floor($duration / 1000) * 1000)->toBeGreaterThanOrEqual(2000);
+    expect(round(microtime(true) - $start))->toBeGreaterThanOrEqual(2);
 });
 
 test('an exception other than a request exception will not be retried', function () {

--- a/tests/Feature/RetryRequestTest.php
+++ b/tests/Feature/RetryRequestTest.php
@@ -6,7 +6,6 @@ use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\Auth\TokenAuthenticator;
-use Symfony\Component\Stopwatch\Stopwatch;
 use Saloon\Exceptions\Request\RequestException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;

--- a/tests/Feature/RetryRequestTest.php
+++ b/tests/Feature/RetryRequestTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\Auth\TokenAuthenticator;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Saloon\Exceptions\Request\RequestException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;

--- a/tests/Unit/AuthenticatorTest.php
+++ b/tests/Unit/AuthenticatorTest.php
@@ -6,6 +6,7 @@ use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\Auth\TokenAuthenticator;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Exceptions\MissingAuthenticatorException;
 use Saloon\Tests\Fixtures\Requests\RequiresAuthRequest;
@@ -139,3 +140,20 @@ test('you can add an authenticator inside of request middleware', function () {
 
     expect($pendingRequest->headers()->get('Authorization'))->toEqual('Bearer yee-haw-request');
 });
+
+test('if you use the authenticate method on a fully constructed pending request it will authenticate right away', function () {
+    $connector = new TestConnector();
+    $pendingRequest = $connector->createPendingRequest(new UserRequest);
+
+    expect($pendingRequest->headers()->all())->toEqual([
+        'Accept' => 'application/json'
+    ]);
+
+    $pendingRequest->authenticate(new TokenAuthenticator('yee-haw-request'));
+
+    expect($pendingRequest->headers()->all())->toEqual([
+        'Accept' => 'application/json',
+        'Authorization' => 'Bearer yee-haw-request'
+    ]);
+});
+

--- a/tests/Unit/AuthenticatorTest.php
+++ b/tests/Unit/AuthenticatorTest.php
@@ -6,8 +6,8 @@ use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\Auth\TokenAuthenticator;
-use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Exceptions\MissingAuthenticatorException;
 use Saloon\Tests\Fixtures\Requests\RequiresAuthRequest;
 use Saloon\Tests\Fixtures\Authenticators\PizzaAuthenticator;
@@ -146,14 +146,13 @@ test('if you use the authenticate method on a fully constructed pending request 
     $pendingRequest = $connector->createPendingRequest(new UserRequest);
 
     expect($pendingRequest->headers()->all())->toEqual([
-        'Accept' => 'application/json'
+        'Accept' => 'application/json',
     ]);
 
     $pendingRequest->authenticate(new TokenAuthenticator('yee-haw-request'));
 
     expect($pendingRequest->headers()->all())->toEqual([
         'Accept' => 'application/json',
-        'Authorization' => 'Bearer yee-haw-request'
+        'Authorization' => 'Bearer yee-haw-request',
     ]);
 });
-


### PR DESCRIPTION
This PR closes #167.

I think in v3 of Saloon, we should change the `sendAndRetry` method to use a `Request` instance and not a `PendingRequest` instance, similar to the paginators. This means when people need to modify the request, they can do. They could even add special middleware or authenticators because it will be just a cloned request.

For now though, I've implemented a solution which means if you run the `authenticate` method on a fully constructed `PendingRequest` it will run the `set` method right away. It's not ideal but it will be fine for now 🤠