### PR TITLE
Saloon V2 fix: expires_in should be optional

### DIFF
--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -173,7 +173,7 @@ trait AuthorizationCodeGrant
 
         $accessToken = $responseData->access_token;
         $refreshToken = $responseData->refresh_token ?? $fallbackRefreshToken;
-        $expiresAt = Date::now()->addSeconds($responseData->expires_in)->toDateTime();
+        $expiresAt = $responseData->expires_in ? Date::now()->addSeconds($responseData->expires_in)->toDateTime() : null;
 
         return $this->createOAuthAuthenticator($accessToken, $refreshToken, $expiresAt);
     }
@@ -183,10 +183,10 @@ trait AuthorizationCodeGrant
      *
      * @param string $accessToken
      * @param string $refreshToken
-     * @param \DateTimeImmutable $expiresAt
-     * @return \Saloon\Contracts\OAuthAuthenticator
+     * @param DateTimeImmutable|null $expiresAt
+     * @return OAuthAuthenticator
      */
-    protected function createOAuthAuthenticator(string $accessToken, string $refreshToken, DateTimeImmutable $expiresAt): OAuthAuthenticator
+    protected function createOAuthAuthenticator(string $accessToken, string $refreshToken, ?DateTimeImmutable $expiresAt = null): OAuthAuthenticator
     {
         return new AccessTokenAuthenticator($accessToken, $refreshToken, $expiresAt);
     }

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -173,7 +173,7 @@ trait AuthorizationCodeGrant
 
         $accessToken = $responseData->access_token;
         $refreshToken = $responseData->refresh_token ?? $fallbackRefreshToken;
-        $expiresAt = $responseData->expires_in ? Date::now()->addSeconds($responseData->expires_in)->toDateTime() : null;
+        $expiresAt = isset($responseData->expires_in) ? Date::now()->addSeconds($responseData->expires_in)->toDateTime() : null;
 
         return $this->createOAuthAuthenticator($accessToken, $refreshToken, $expiresAt);
     }

--- a/tests/Unit/Oauth2/AccessTokenAuthenticatorTest.php
+++ b/tests/Unit/Oauth2/AccessTokenAuthenticatorTest.php
@@ -56,3 +56,11 @@ test('can be constructed with just an access token and expiry', function () {
     expect($authenticator->hasExpired())->toBeTrue();
     expect($authenticator->hasNotExpired())->toBeFalse();
 });
+
+test('it allows expires_in to be optional', function () {
+    $authenticator = new AccessTokenAuthenticator('access', 'refresh', null);
+
+    expect($authenticator->getExpiresAt())->toBeNull();
+    expect($authenticator->isRefreshable())->toBeTrue();
+    expect($authenticator->isNotRefreshable())->toBeFalse();
+});


### PR DESCRIPTION
# Fix Expires_In

[The OAuth Spec](https://www.rfc-editor.org/rfc/rfc6749#section-4.2.2) lists `expires_in` as an optional parameter, one which salesforce does not use - which I discovered [here](https://github.com/MyOutDeskLLC/SalesforcePhp/tree/feature/saloon-v2).

Issue:
* OAuth connections that do not use this parameter, despite it being recommended, will cause a `Undefined property: stdClass::$expires_in` error

This PR 
* checks `expires_in` for null and allows `createOAuthAuthenticator` to accept `DateTimeImmutable|null`. 
* adds a new test  `it allows expires_in to be optional` 

I have confirmed all tests still pass with this adjustment. 