### PR TITLE
Feature | Added request modifier to OAuth2 process

### DIFF
--- a/src/Helpers/OAuth2/OAuthConfig.php
+++ b/src/Helpers/OAuth2/OAuthConfig.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Saloon\Helpers\OAuth2;
 
 use Saloon\Traits\Makeable;
+use Saloon\Contracts\Request;
 use Saloon\Exceptions\OAuthConfigValidationException;
 
 /**
@@ -55,6 +56,13 @@ class OAuthConfig
      * @var string
      */
     protected string $userEndpoint = 'user';
+
+    /**
+     * Callable that modifies the OAuth requests
+     *
+     * @var callable(\Saloon\Contracts\Request): (void)|null
+     */
+    protected mixed $requestModifier = null;
 
     /**
      * The default scopes that will be applied to every authorization URL.
@@ -222,6 +230,38 @@ class OAuthConfig
         $this->defaultScopes = $defaultScopes;
 
         return $this;
+    }
+
+    /**
+     * Set the request modifier callable which can be used to modify the request being sent
+     *
+     * @param callable(\Saloon\Contracts\Request): (void) $requestModifier
+     * @return $this
+     */
+    public function setRequestModifier(callable $requestModifier): static
+    {
+        $this->requestModifier = $requestModifier;
+
+        return $this;
+    }
+
+    /**
+     * Invoke the OAuth2 config request modifier
+     *
+     * @param \Saloon\Contracts\Request $request
+     * @return \Saloon\Contracts\Request
+     */
+    public function invokeRequestModifier(Request $request): Request
+    {
+        $requestModifier = $this->requestModifier;
+
+        if (is_null($requestModifier)) {
+            return $request;
+        }
+
+        $requestModifier($request);
+
+        return $request;
     }
 
     /**

--- a/src/Helpers/OAuth2/OAuthConfig.php
+++ b/src/Helpers/OAuth2/OAuthConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Helpers\OAuth2;
 
+use Closure;
 use Saloon\Traits\Makeable;
 use Saloon\Contracts\Request;
 use Saloon\Exceptions\OAuthConfigValidationException;
@@ -62,7 +63,7 @@ class OAuthConfig
      *
      * @var \Closure(\Saloon\Contracts\Request): (void)|null
      */
-    protected Closure $requestModifier = null;
+    protected ?Closure $requestModifier = null;
 
     /**
      * The default scopes that will be applied to every authorization URL.
@@ -235,9 +236,7 @@ class OAuthConfig
     /**
      * Set the request modifier callable which can be used to modify the request being sent
      *
-     * @template TRequest of \Saloon\Contracts\Request
-     *
-     * @param callable(TRequest): (void) $requestModifier
+     * @param callable(\Saloon\Contracts\Request): (void) $requestModifier
      * @return $this
      */
     public function setRequestModifier(callable $requestModifier): static

--- a/src/Helpers/OAuth2/OAuthConfig.php
+++ b/src/Helpers/OAuth2/OAuthConfig.php
@@ -60,9 +60,9 @@ class OAuthConfig
     /**
      * Callable that modifies the OAuth requests
      *
-     * @var callable(\Saloon\Contracts\Request): (void)|null
+     * @var \Closure(\Saloon\Contracts\Request): (void)|null
      */
-    protected mixed $requestModifier = null;
+    protected Closure $requestModifier = null;
 
     /**
      * The default scopes that will be applied to every authorization URL.
@@ -235,12 +235,14 @@ class OAuthConfig
     /**
      * Set the request modifier callable which can be used to modify the request being sent
      *
-     * @param callable(\Saloon\Contracts\Request): (void) $requestModifier
+     * @template TRequest of \Saloon\Contracts\Request
+     *
+     * @param callable(TRequest): (void) $requestModifier
      * @return $this
      */
     public function setRequestModifier(callable $requestModifier): static
     {
-        $this->requestModifier = $requestModifier;
+        $this->requestModifier = $requestModifier(...);
 
         return $this;
     }
@@ -248,8 +250,10 @@ class OAuthConfig
     /**
      * Invoke the OAuth2 config request modifier
      *
-     * @param \Saloon\Contracts\Request $request
-     * @return \Saloon\Contracts\Request
+     * @template TRequest of \Saloon\Contracts\Request
+     *
+     * @param TRequest $request
+     * @return TRequest
      */
     public function invokeRequestModifier(Request $request): Request
     {

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -216,15 +216,22 @@ trait AuthorizationCodeGrant
     /**
      * Get the authenticated user.
      *
+     * @template TRequest of \Saloon\Contracts\Request
+     *
      * @param \Saloon\Contracts\OAuthAuthenticator $oauthAuthenticator
+     * @param callable(TRequest): (void)|null $requestModifier
      * @return \Saloon\Contracts\Response
      * @throws \ReflectionException
      * @throws \Saloon\Exceptions\InvalidResponseClassException
      * @throws \Saloon\Exceptions\PendingRequestException
      */
-    public function getUser(OAuthAuthenticator $oauthAuthenticator): Response
+    public function getUser(OAuthAuthenticator $oauthAuthenticator, ?callable $requestModifier = null): Response
     {
         $request = GetUserRequest::make($this->oauthConfig())->authenticate($oauthAuthenticator);
+
+        if (is_callable($requestModifier)) {
+            $requestModifier($request);
+        }
 
         $request = $this->oauthConfig()->invokeRequestModifier($request);
 

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -120,6 +120,8 @@ trait AuthorizationCodeGrant
 
         $request = new GetAccessTokenRequest($code, $this->oauthConfig());
 
+        $request = $this->oauthConfig()->invokeRequestModifier($request);
+
         if (is_callable($requestModifier)) {
             $requestModifier($request);
         }
@@ -162,6 +164,8 @@ trait AuthorizationCodeGrant
         }
 
         $request = new GetRefreshTokenRequest($this->oauthConfig(), $refreshToken);
+
+        $request = $this->oauthConfig()->invokeRequestModifier($request);
 
         if (is_callable($requestModifier)) {
             $requestModifier($request);
@@ -220,9 +224,11 @@ trait AuthorizationCodeGrant
      */
     public function getUser(OAuthAuthenticator $oauthAuthenticator): Response
     {
-        return $this->send(
-            GetUserRequest::make($this->oauthConfig())->authenticate($oauthAuthenticator)
-        );
+        $request = GetUserRequest::make($this->oauthConfig())->authenticate($oauthAuthenticator);
+
+        $request = $this->oauthConfig()->invokeRequestModifier($request);
+
+        return $this->send($request);
     }
 
     /**

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -96,13 +96,13 @@ trait AuthorizationCodeGrant
     /**
      * Get the access token.
      *
-     * @template TRequest \Saloon\Contracts\Request
+     * @template TRequest of \Saloon\Contracts\Request
      *
      * @param string $code
      * @param string|null $state
      * @param string|null $expectedState
      * @param bool $returnResponse
-     * @param callable(TRequest): TRequest|null $requestModifier
+     * @param callable(TRequest): (void)|null $requestModifier
      * @return \Saloon\Contracts\OAuthAuthenticator|\Saloon\Contracts\Response
      * @throws \ReflectionException
      * @throws \Saloon\Exceptions\InvalidResponseClassException
@@ -138,11 +138,11 @@ trait AuthorizationCodeGrant
     /**
      * Refresh the access token.
      *
-     * @template TRequest \Saloon\Contracts\Request
+     * @template TRequest of \Saloon\Contracts\Request
      *
      * @param \Saloon\Contracts\OAuthAuthenticator|string $refreshToken
      * @param bool $returnResponse
-     * @param callable(TRequest): TRequest|null $requestModifier
+     * @param callable(TRequest): (void)|null $requestModifier
      * @return \Saloon\Contracts\OAuthAuthenticator|\Saloon\Contracts\Response
      * @throws \ReflectionException
      * @throws \Saloon\Exceptions\InvalidResponseClassException

--- a/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
+++ b/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Saloon\Contracts\Request;
 use Saloon\Helpers\Str;
 use Saloon\Helpers\Date;
 use Saloon\Http\Response;
+use Saloon\Contracts\Request;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Exceptions\InvalidStateException;


### PR DESCRIPTION
This PR adds an optional `requestModifier` property to the access token and refresh token methods to make it easier to tap into the request and make some final adjustments that is vendor specific (like supplying scope again)

```php
$auth->getAccessToken($code, requestModifier: function (Request $request) {
    //
});

$auth->getRefreshToken($code, requestModifier: function (Request $request) {
    //
});

$auth->getUser($code, requestModifier: function (Request $request) {
    //
});
```

This PR also adds a global request modifier for the whole OAuth2 config so you can easily modify any request sent. 

```php
protected function defaultOauthConfig(): OAuthConfig
{
    return OAuthConfig::make()
        ->setClientId('my-client-id')
        ->setClientSecret('my-client-secret')
        ->setRedirectUri('https://my-app.saloon.dev/auth/callback')
	->setRequestModifier(function (Request $request) {
              // $request->headers()->add();
        )},
}
```

@juse-less How did I do on the generics? 😁