### PR TITLE
Add additional query params to the getAuthorizationUrl method for V2

### DIFF
--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -63,7 +63,7 @@ trait AuthorizationCodeGrant
      * @return string
      * @throws \Saloon\Exceptions\OAuthConfigValidationException
      */
-    public function getAuthorizationUrl(array $scopes = [], string $state = null, string $scopeSeparator = ' '): string
+    public function getAuthorizationUrl(array $scopes = [], string $state = null, string $scopeSeparator = ' ', array $additionalQueryParameters = []): string
     {
         $config = $this->oauthConfig();
 
@@ -81,6 +81,7 @@ trait AuthorizationCodeGrant
             'client_id' => $clientId,
             'redirect_uri' => $redirectUri,
             'state' => $this->state,
+            ...$additionalQueryParameters
         ];
 
         $query = http_build_query($queryParameters, '', '&', PHP_QUERY_RFC3986);

--- a/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
+++ b/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
@@ -60,6 +60,21 @@ test('default state is generated automatically with every authorization url if s
     expect(Str::endsWith($url, $state))->toBeTrue();
 });
 
+test('additional query parameters can be added passed to the authorization url', function () {
+    $connector = new OAuth2Connector;
+
+    $url = $connector->getAuthorizationUrl(
+        ['scope-1', 'scope-2'],
+        state: 'my-state',
+        additionalQueryParameters: ['another-param'=>'another-value', 'yee'=>'haw']
+    );
+
+    expect(str_ends_with($url, 'another-param=another-value&yee=haw'))->toBeTrue();
+    expect($url)->toEqual(
+        'https://oauth.saloon.dev/authorize?response_type=code&scope=scope-1%20scope-2&client_id=client-id&redirect_uri=https%3A%2F%2Fmy-app.saloon.dev%2Fauth%2Fcallback&state=my-state&another-param=another-value&yee=haw'
+    );
+});
+
 test('you can request a token from a connector', function () {
     $mockClient = new MockClient([
         MockResponse::make(['access_token' => 'access', 'refresh_token' => 'refresh', 'expires_in' => 3600], 200),


### PR DESCRIPTION
This PR adds the functionally to optionally add additional query parameters to the generated authorization URL. 
This is useful when certain providers require additional flags and options to be added to the authorization url. 

