### PR TITLE
[PoC] Add option to get connector on DTO

### DIFF
--- a/src/Contracts/DataObjects/WithConnector.php
+++ b/src/Contracts/DataObjects/WithConnector.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Contracts\DataObjects;
+
+use Saloon\Contracts\Connector;
+
+interface WithConnector
+{
+    /**
+     * Set the request connector on the data object.
+     *
+     * @param \Saloon\Contracts\Connector $connector
+     * @return $this
+     */
+    public function setConnector(Connector $connector): static;
+
+    /**
+     * Get the request connector on the data object.
+     *
+     * @return \Saloon\Contracts\Connector
+     */
+    public function getConnector(): Connector;
+}

--- a/src/Traits/Responses/HasConnector.php
+++ b/src/Traits/Responses/HasConnector.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Traits\Responses;
+
+use Saloon\Contracts\Connector;
+
+trait HasConnector
+{
+    /**
+     * The connector used to make the request.
+     *
+     * @var \Saloon\Contracts\Connector
+     */
+    protected Connector $connector;
+
+    /**
+     * Set the connector on the data object.
+     *
+     * @param \Saloon\Contracts\Connector $connector
+     * @return $this
+     */
+    public function setConnector(Connector $connector): static
+    {
+        $this->connector = $connector;
+
+        return $this;
+    }
+
+    /**
+     * Get the connector on the data object.
+     *
+     * @return \Saloon\Contracts\Connector
+     */
+    public function getConnector(): Connector
+    {
+        return $this->connector;
+    }
+}

--- a/src/Traits/Responses/HasResponseHelpers.php
+++ b/src/Traits/Responses/HasResponseHelpers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Traits\Responses;
 
+use Saloon\Contracts\DataObjects\WithConnector;
 use Throwable;
 use SimpleXMLElement;
 use Saloon\Helpers\Arr;
@@ -135,6 +136,10 @@ trait HasResponseHelpers
 
         if ($dataObject instanceof WithResponse) {
             $dataObject->setResponse($this);
+        }
+
+        if ($dataObject instanceof WithConnector) {
+            $dataObject->setConnector($this->pendingRequest->getConnector());
         }
 
         return $dataObject;


### PR DESCRIPTION
Hey Sam! 👋

I made a little proof of concept that will allow you to get the connector that made the request that resulted in the response.
I have no idea if this is something you would like to solve the way I did it, but I thought it would be cool if you could do some sort of chaining like this.

These changes allow you to use a dto object for additional API calls on subresources.

```php
$product = $api
->products()
->get('977a77b5-79a6-4714-9614-bfc751b15b75')
->dto();

$policies = $product->policies()->all()->json();
```

```php
class Product implements WithResponse, WithConnector
{
    use HasResponse;
    use HasConnector;

    public function __construct(
        public string $id,
        public string $name,
    ) {
    }

    public static function fromResponse(Response $response): self
    {
        $data = $response->json('data');

        return new static(
            id: $data['id'],
            name: $data['name'],
        );
    }

    public function policies()
    {
        return new PoliciesResource(connector: $this->getConnector(), productId: $this->id);
    }
}
```

One additional thing I thought about is adding some sort of trait like the one that always throws an exception on failure; is one that always returns the dto on success or throws an exception on failure, so you never have to call `dto`.

```php

try {
  $productName = $api
  ->products()
  ->get('977a77b5-79a6-4714-9614-bfc751b15b75')->name
} catch (\Exception $e) {
  dd('something went wrong');
}
```

Both are ideas so happy to discuss and it's also fine of course if you think differently about this.
Thanks for creating Saloon! I've already used v1 but v2 is even better! 😎
