### PR TITLE
Update response with generic template for typehinting DTOS

### DIFF
--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -10,6 +10,9 @@ use Illuminate\Support\Collection;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * @template TDto
+ */
 interface Response extends HasHeaders
 {
     /**
@@ -114,7 +117,7 @@ interface Response extends HasHeaders
     /**
      * Convert the response into a DTO
      *
-     * @return mixed
+     * @return TDto
      */
     public function dto(): mixed;
 


### PR DESCRIPTION
This will allow people to typehint a function with Response<MyDTO>, meaning when they call ->dto() on a response, the IDE will know that it's MyDTO and not mixed.