### PR TITLE
Feature | Installed parallel testing pest plugin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,4 +44,4 @@ jobs:
         run: |
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest -p

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "illuminate/collections": "^9.39",
         "league/flysystem": "^3.0",
         "pestphp/pest": "^1.21",
+        "pestphp/pest-plugin-parallel": "^1.2",
         "phpstan/phpstan": "^1.9",
         "spatie/ray": "^1.33",
         "symfony/dom-crawler": "^6.0"


### PR DESCRIPTION
Since github workflow runs over a 2-core machine, atleast in "free" tier, we can run the tests using parallel testing 