### PR TITLE
Fixed incorrect .editorconfig path/extension expansion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{yml, yaml, neon, neon.dist}]
+[*.{yml,yaml,neon,neon.dist}]
 indent_size = 2


### PR DESCRIPTION
Hey, @Sammyjo20.

I realised I incorrectly added spaces into the path/extension expansion, when adding the NEON/PHPStan stuff for v2.
I've removed the spaces.
So editor config should now correctly set indentation on YAML and NEON files.