### PR TITLE
File handles are not properly closed until a process fully terminates

### DIFF
--- a/tests/Unit/MiddlewarePipelineTest.php
+++ b/tests/Unit/MiddlewarePipelineTest.php
@@ -323,4 +323,4 @@ test('a middleware pipeline is correctly destructed when finished', function ():
     unset($pipeline);
 
     expect($pipelineReference->get())->toBeNull();
-})->skip();
+});


### PR DESCRIPTION
Please bear with me on this one. It's a tricky problem to even debug, let alone describe.

For some reason, PHP is not destructing Closures, or 'things' using Closures, correctly, keeping unused classes intact.

In this case, our middleware pipeline wrapping in the MiddlewarePipeline ([1](https://github.com/Sammyjo20/Saloon/blob/e6cfb32f728e91eaebc062a86f20bb632ff40cd1/src/Helpers/MiddlewarePipeline.php#L47), [2](https://github.com/Sammyjo20/Saloon/blob/e6cfb32f728e91eaebc062a86f20bb632ff40cd1/src/Helpers/MiddlewarePipeline.php#L75)) is therefore left intact, despite not being used anywhere.

This subsequently cause classes like the Connector, Request, and PendingRequest to also not destruct.
Even after the variable or property containing it is unset.

In terms of Connector, this also means that the backing client is also not destructed.
At least with Guzzle, this leaves open file handles until the process running it is terminated.
This means that background processing like Laravel Queues will 'leak' file handles between Jobs, eventually causing the server to run out of them.

I have found a workaround I will commit in a bit.
I just need to see if other tests work here in GitHub Actions, or if they start failing like they do locally for me.

A note on this, though:
This PR doesn't solve the same problem occurring when you set a Closure as a property in, say, the Connector.
I'm not sure we actually can't solve that.

What we can do, is using a hack I came up with, for those wrapping Closures in the MiddlewarePipeline, so that we solve the more critical issue right now.

<details>
<summary>Leaving some information here, on the tests I used</summary>

The actual testing repo can be found here: https://github.com/juse-less/laravel-closure-properties-in-queue-issue.
Initially it looked like this only ever happened in Laravels Queue.

But I was able to replicate everything in a 1-file base-PHP project (not committed).
The underlying issue, especially the things we can't 'patch' for everyone can be found in app/Console/Commands and app/Jobs.
Classes used for testing can be found directly under app/.

See [these snippets](https://github.com/juse-less/laravel-closure-properties-in-queue-issue/blob/c86604511e8e83c3f4efef76d43e341ce01cb221/app/Connector.php#L14-L50) for the issue with Closure-based properties.
The code in the `boot()` method is the gist of the solution I'll apply here.
</details>

----------
There are tidier ways to handle this, like create 'Pipes' specifically for Requests, and Responses.
However, I found that it was wee bit too many code changes for this.
And it could potentially be seen as a breaking change (at least the things I made).
We should probably refactor to something like that for v3, though.