### PR TITLE
Fix | Rewinds the body if it is seekable

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -105,7 +105,14 @@ class Response implements ResponseContract
      */
     public function body(): string
     {
-        return (string)$this->stream();
+        $stream = $this->stream();
+        $body = $stream->getContents();
+
+        if ($stream->isSeekable()) {
+            $stream->rewind();
+        }
+
+        return $body;
     }
 
     /**

--- a/src/Traits/Responses/HasResponseHelpers.php
+++ b/src/Traits/Responses/HasResponseHelpers.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Traits\Responses;
 
+use LogicException;
 use Throwable;
 use SimpleXMLElement;
 use Saloon\Helpers\Arr;
@@ -143,13 +144,13 @@ trait HasResponseHelpers
     /**
      * Convert the response into a DTO or throw a LogicException if the response failed
      *
-     * @throws \LogicException
+     * @throws LogicException
      * @return mixed
      */
     public function dtoOrFail(): mixed
     {
         if ($this->failed()) {
-            throw new \LogicException('Unable to create data transfer object as the response has failed.', 0, $this->toException());
+            throw new LogicException('Unable to create data transfer object as the response has failed.', 0, $this->toException());
         }
 
         return $this->dto();

--- a/src/Traits/Responses/HasResponseHelpers.php
+++ b/src/Traits/Responses/HasResponseHelpers.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Saloon\Traits\Responses;
 
-use LogicException;
 use Throwable;
+use LogicException;
 use SimpleXMLElement;
 use Saloon\Helpers\Arr;
 use Illuminate\Support\Collection;

--- a/tests/Unit/SaloonResponseTest.php
+++ b/tests/Unit/SaloonResponseTest.php
@@ -238,3 +238,15 @@ test('the dom method will return a crawler instance', function () {
     expect($response->dom())->toBeInstanceOf(Crawler::class);
     expect($response->dom())->toEqual(new Crawler($dom));
 });
+
+test('when using the json body method the stream is rewound back to the start', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['foo' => 'bar'], 200, ['X-Custom-Header' => 'Howdy']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+
+    expect($response->json())->toEqual(['foo' => 'bar']);
+    expect($response->body())->toEqual('{"foo":"bar"}');
+    expect($response->object())->toEqual((object)['foo' => 'bar']);
+});

--- a/tests/Unit/SaloonResponseTest.php
+++ b/tests/Unit/SaloonResponseTest.php
@@ -239,7 +239,7 @@ test('the dom method will return a crawler instance', function () {
     expect($response->dom())->toEqual(new Crawler($dom));
 });
 
-test('when using the json body method the stream is rewound back to the start', function () {
+test('when using the body methods the stream is rewound back to the start', function () {
     $mockClient = new MockClient([
         MockResponse::make(['foo' => 'bar'], 200, ['X-Custom-Header' => 'Howdy']),
     ]);


### PR DESCRIPTION
This PR fixes an issue where if you called a body method on a response and then used a different one after, it would be an empty string. This was because the `body()` method wasn't rewinding the underlying stream.

This PR fixes this issue.