### PR TITLE
Cast total results to int before returning

### DIFF
--- a/src/Http/Paginators/Paginator.php
+++ b/src/Http/Paginators/Paginator.php
@@ -338,7 +338,7 @@ abstract class Paginator implements PaginatorContract
             throw new PaginatorException('Unable to calculate the total results from the response. Make sure the total key is correct.');
         }
 
-        return $total;
+        return (int) $total;
     }
 
     /**


### PR DESCRIPTION
This PR forces the results of the totalResults method on the paginator to return an int. 

The method already has return type of int however some API don't follow conventions and actually supply this value as a string. 

```json
{
	"ResultInfo": {
		"page": "1",
		"per_page": "20",
		"total_count": "47"
	},
}
```

Without this PR, this results in an error due to a mismatch in the return type. 

