### PR TITLE
Fix | Throw FatalRequestException when Guzzle doesn't return a response in the RequestException

### DIFF
--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -76,7 +76,7 @@ parameters:
 			path: src/Http/Response.php
 
 		-
-			message: "#^Method Saloon\\\\Http\\\\Senders\\\\GuzzleSender\\:\\:createRequestOptions\\(\\) should return array\\<'allow_redirects'\\|'auth'\\|'body'\\|'cert'\\|'connect_timeout'\\|'cookies'\\|'debug'\\|'decode_content'\\|'delay'\\|'expect'\\|'force_ip_resolve'\\|'form_params'\\|'headers'\\|'http_errors'\\|'idn_conversion'\\|'json'\\|'multipart'\\|'on_headers'\\|'on_stats'\\|'progress'\\|'proxy'\\|'query'\\|'read_timeout'\\|'sink'\\|'ssl_key'\\|'stream'\\|'synchronous'\\|'timeout'\\|'verify'\\|'version', mixed\\> but returns array\\<string, mixed\\>\\.$#"
+			message: "#^Method Saloon\\\\Http\\\\Senders\\\\GuzzleSender\\:\\:createRequestOptions\\(\\) should return array\\<'allow_redirects'\\|'auth'\\|'body'\\|'cert'\\|'connect_timeout'\\|'cookies'\\|'crypto_method'\\|'debug'\\|'decode_content'\\|'delay'\\|'expect'\\|'force_ip_resolve'\\|'form_params'\\|'headers'\\|'http_errors'\\|'idn_conversion'\\|'json'\\|'multipart'\\|'on_headers'\\|'on_stats'\\|'progress'\\|'proxy'\\|'query'\\|'read_timeout'\\|'sink'\\|'ssl_key'\\|'stream'\\|'synchronous'\\|'timeout'\\|'verify'\\|'version', mixed\\> but returns array\\<string, mixed\\>\\.$#"
 			count: 2
 			path: src/Http/Senders/GuzzleSender.php
 

--- a/tests/Feature/RequestExceptionTest.php
+++ b/tests/Feature/RequestExceptionTest.php
@@ -12,6 +12,7 @@ use Saloon\Exceptions\Request\RequestException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Exceptions\Request\FatalRequestException;
 use Saloon\Tests\Fixtures\Requests\BadResponseRequest;
 use Saloon\Tests\Fixtures\Connectors\BadResponseConnector;
 use Saloon\Tests\Fixtures\Exceptions\CustomRequestException;
@@ -244,3 +245,27 @@ test('you can customise if saloon determines if a request has failed on a reques
 
     expect($responseB->failed())->toBeTrue();
 });
+
+test('the sender will throw a FatalRequestException if it cannot connect to a site using synchronous', function (string $url) {
+    $connector = new TestConnector($url);
+    $request = new UserRequest();
+
+    $this->expectException(FatalRequestException::class);
+
+    $response = $connector->send($request);
+})->with([
+    'https://saloon.saloon.test',
+    'https://saloon.doesnt-exist',
+]);
+
+test('the sender will throw a FatalRequestException if it cannot connect to a site using asynchronous', function (string $url) {
+    $connector = new TestConnector($url);
+    $request = new UserRequest();
+
+    $this->expectException(FatalRequestException::class);
+
+    $connector->sendAsync($request)->wait();
+})->with([
+    'https://saloon.saloon.test',
+    'https://saloon.doesnt-exist',
+]);

--- a/tests/Fixtures/Connectors/TestConnector.php
+++ b/tests/Fixtures/Connectors/TestConnector.php
@@ -14,13 +14,23 @@ class TestConnector extends Connector
     public bool $unique = false;
 
     /**
+     * Constructor
+     *
+     * @param string|null $url
+     */
+    public function __construct(protected ?string $url = null)
+    {
+        //
+    }
+
+    /**
      * Define the base url of the api.
      *
      * @return string
      */
     public function resolveBaseUrl(): string
     {
-        return apiUrl();
+        return $this->url ?? apiUrl();
     }
 
     /**


### PR DESCRIPTION
Fixes #188 

There's a scenario often found when dealing with Invalid SSL certificates that Guzzle won't throw a `ConnectException`, but it will throw a `RequestException` without a response. Saloon will now check if that response is not provided and if it's null, we will throw a `FatalRequestException`.  