### PR TITLE
Fix | Added support for Guzzle promises v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.5",
-        "guzzlehttp/promises": "^1.5",
+        "guzzlehttp/promises": "^1.5 || ^2.0",
         "psr/http-message": "^1.1 || ^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds support for both v1 and v2 of Guzzle's promise library. This also fixes an issue that some users were having when installing Saloon without a version constraint which would cause people to install Saloon v1 and not v2.