### PR TITLE
Feature | Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Hey @Sammyjo20 👋 

This PR goes back to the conversation we had on Twitter a few days ago. This is a very basic Dependabot config that could be used for Saloon. One thing I like to have is a restriction on the number of open Dependabot PR's that I have at any one time, I usually go for 5 but whatever works for you 😄 