### PR TITLE
Feature | JSON flags on JsonBodyRepository

### DIFF
--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -16,11 +16,6 @@ parameters:
 			path: src/Http/Connector.php
 
 		-
-			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this\\(Saloon\\\\Http\\\\Connector\\), TValue\\)\\: void expects TValue, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 2
-			path: src/Http/Connector.php
-
-		-
 			message: "#^Parameter \\#1 \\$contents of static method Saloon\\\\Data\\\\RecordedResponse\\:\\:fromFile\\(\\) expects string, bool\\|string given\\.$#"
 			count: 1
 			path: src/Http/Faking/Fixture.php
@@ -51,16 +46,6 @@ parameters:
 			path: src/Http/PendingRequest.php
 
 		-
-			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this\\(Saloon\\\\Http\\\\PendingRequest\\), TValue\\)\\: void expects TValue, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 2
-			path: src/Http/PendingRequest.php
-
-		-
-			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this\\(Saloon\\\\Http\\\\Request\\), TValue\\)\\: void expects TValue, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 2
-			path: src/Http/Request.php
-
-		-
 			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\)\\: mixed, \\(callable\\(\\)\\: mixed\\)\\|object given\\.$#"
 			count: 2
 			path: src/Http/Response.php
@@ -81,26 +66,6 @@ parameters:
 			path: src/Http/Senders/GuzzleSender.php
 
 		-
-			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this\\(Saloon\\\\Repositories\\\\ArrayStore\\), TValue\\)\\: void expects TValue, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 2
-			path: src/Repositories/ArrayStore.php
-
-		-
-			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this\\(Saloon\\\\Repositories\\\\Body\\\\ArrayBodyRepository\\), TValue\\)\\: void expects TValue, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 2
-			path: src/Repositories/Body/ArrayBodyRepository.php
-
-		-
-			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this\\(Saloon\\\\Repositories\\\\Body\\\\MultipartBodyRepository\\), TValue\\)\\: void expects TValue, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 2
-			path: src/Repositories/Body/MultipartBodyRepository.php
-
-		-
-			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this\\(Saloon\\\\Repositories\\\\Body\\\\StringBodyRepository\\), TValue\\)\\: void expects TValue, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
-			count: 2
-			path: src/Repositories/Body/StringBodyRepository.php
-
-		-
 			message: "#^Call to an undefined method GuzzleHttp\\\\Promise\\\\PromiseInterface\\|Saloon\\\\Contracts\\\\Response\\:\\:json\\(\\)\\.$#"
 			count: 1
 			path: src/Http/Paginators/Paginator.php
@@ -111,6 +76,41 @@ parameters:
 			path: src/Http/Paginators/Paginator.php
 
 		-
-			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this\\(Saloon\\\\Repositories\\\\IntegerStore\\), TValue\\)\\: void expects TValue, array\\|float\\|int\\|string\\|false\\|null given\\.$#"
+			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this, TValue\\)\\: void expects TValue\\, array\\|float\\|int\\|string\\|false\\|null given.$#"
+			count: 2
+			path: src/Http/Connector.php
+
+		-
+			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this, TValue\\)\\: void expects TValue\\, array\\|float\\|int\\|string\\|false\\|null given.$#"
+			count: 2
+			path: src/Http/PendingRequest.php
+
+		-
+			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this, TValue\\)\\: void expects TValue\\, array\\|float\\|int\\|string\\|false\\|null given.$#"
+			count: 2
+			path: src/Http/Request.php
+
+		-
+			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this, TValue\\)\\: void expects TValue\\, array\\|float\\|int\\|string\\|false\\|null given.$#"
+			count: 2
+			path: src/Repositories/ArrayStore.php
+
+		-
+			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this, TValue\\)\\: void expects TValue\\, array\\|float\\|int\\|string\\|false\\|null given.$#"
 			count: 2
 			path: src/Repositories/IntegerStore.php
+
+		-
+			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this, TValue\\)\\: void expects TValue\\, array\\|float\\|int\\|string\\|false\\|null given.$#"
+			count: 2
+			path: src/Repositories/Body/ArrayBodyRepository.php
+
+		-
+			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this, TValue\\)\\: void expects TValue\\, array\\|float\\|int\\|string\\|false\\|null given.$#"
+			count: 2
+			path: src/Repositories/Body/MultipartBodyRepository.php
+
+		-
+			message: "#^Parameter \\#2 \\$ of callable callable\\(\\$this, TValue\\)\\: void expects TValue\\, array\\|float\\|int\\|string\\|false\\|null given.$#"
+			count: 2
+			path: src/Repositories/Body/StringBodyRepository.php

--- a/src/Repositories/Body/JsonBodyRepository.php
+++ b/src/Repositories/Body/JsonBodyRepository.php
@@ -7,13 +7,48 @@ namespace Saloon\Repositories\Body;
 class JsonBodyRepository extends ArrayBodyRepository
 {
     /**
+     * JSON encoding flags
+     *
+     * Use a Bitmask to separate other flags. For example: JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+     *
+     * @var int
+     */
+    protected int $jsonFlags = JSON_THROW_ON_ERROR;
+
+    /**
+     * Set the JSON encoding flags
+     *
+     * Must be a bitmask like: ->setJsonFlags(JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR)
+     *
+     * @param int $flags
+     * @return $this
+     */
+    public function setJsonFlags(int $flags): static
+    {
+        $this->jsonFlags = $flags;
+
+        return $this;
+    }
+
+    /**
+     * Get the JSON encoding flags
+     *
+     * @return int
+     */
+    public function getJsonFlags(): int
+    {
+        return $this->jsonFlags;
+    }
+
+    /**
      * Convert the body repository into a string.
      *
      * @return string
-     * @throws \JsonException
      */
     public function __toString(): string
     {
-        return json_encode($this->all(), JSON_THROW_ON_ERROR);
+        $json = json_encode($this->all(), $this->getJsonFlags());
+
+        return $json === false ? '' : $json;
     }
 }

--- a/tests/Feature/Body/HasJsonBodyTest.php
+++ b/tests/Feature/Body/HasJsonBodyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Saloon\Debugging\DebugData;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockResponse;
 use Psr\Http\Message\RequestInterface;
@@ -47,4 +48,32 @@ test('the guzzle sender properly sends it', function () {
     });
 
     $connector->send($request);
+});
+
+test('you can specify different json flags that the body repository should use', function () {
+    $request = new HasJsonBodyRequest();
+    $body = $request->body();
+
+    // We'll add a property with slashes
+
+    $body->add('url', 'https://docs.saloon.dev');
+
+    // By default, PHP will escape slashes
+
+    expect((string)$body)->toEqual('{"name":"Sam","catchphrase":"Yeehaw!","url":"https:\/\/docs.saloon.dev"}');
+
+    // Now we'll customise the flags
+
+    $body->setJsonFlags(JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+
+    expect((string)$body)->toEqual('{"name":"Sam","catchphrase":"Yeehaw!","url":"https://docs.saloon.dev"}');
+
+    expect($body->getJsonFlags())->toEqual(JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+});
+
+test('the JsonBodyRepository uses the JSON_THROW_ON_ERROR default flag', function () {
+    $request = new HasJsonBodyRequest();
+    $body = $request->body();
+
+    expect($body->getJsonFlags())->toEqual(JSON_THROW_ON_ERROR);
 });

--- a/tests/Feature/Body/HasJsonBodyTest.php
+++ b/tests/Feature/Body/HasJsonBodyTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Saloon\Debugging\DebugData;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockResponse;
 use Psr\Http\Message\RequestInterface;


### PR DESCRIPTION
Fixes #194 

This PR adds support to customise the JSON flags that are used to encode the JSON body repository in Saloon. For example, if you want to make sure that body that contains slashes doesn't get escaped, you can use the `setJsonFlags` method on the `body` method to overwrite them.

They use a "bitmask" which is slightly different from arrays. For example, to set both `JSON_THROW_ON_ERROR` and `JSON_UNESCAPED_SLASHES` you would need to separate them with a pipe (`|`)

```php
$request = new GetServersRequest;
$request->body()->setJsonFlags(JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);

$connector->send($request);
```

As Saloon recommends keeping logic standardised inside of requests, I would recommend that you set this within the `__construct` or the `boot` method of the request...

```php
__construct()
{
     $this->body()->setJsonFlags(JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
}
```

Side note, @juse-less - any idea why it seems like it's ignoring our baseline file now and spitting out loads of the "ignored" errors?