### PR TITLE
(V1) Fix | Use of `null` in MockResponse data

### DIFF
--- a/src/Http/MockResponse.php
+++ b/src/Http/MockResponse.php
@@ -148,6 +148,10 @@ class MockResponse
             return json_encode($data);
         }
 
+        if (empty($data)) {
+            return null;
+        }
+
         return $data;
     }
 

--- a/src/Traits/CollectsData.php
+++ b/src/Traits/CollectsData.php
@@ -76,7 +76,7 @@ trait CollectsData
     }
 
     /**
-     *  Get all data or filter with a key.
+     * Get all data or filter with a key.
      *
      * @param string|null $key
      * @return mixed

--- a/src/Traits/CollectsHeaders.php
+++ b/src/Traits/CollectsHeaders.php
@@ -96,12 +96,12 @@ trait CollectsHeaders
     /**
      * Get an individual header
      *
-     * @param string|null $key
-     * @return array
+     * @param string $key
+     * @return string
      */
     public function getHeader(string $key): string
     {
-        return $this->getHeaders($key);
+        return $this->getHeaders($key) ?? '';
     }
 
     /**

--- a/tests/Unit/MockResponseTest.php
+++ b/tests/Unit/MockResponseTest.php
@@ -68,3 +68,12 @@ test('a response can be a custom response class', function () {
     expect($response)->customCastMethod()->toBeInstanceOf(UserData::class);
     expect($response)->foo()->toBe('bar');
 });
+
+test('a mock response can have null for the data', function () {
+    $mockClient = new MockClient([MockResponse::make(null, 200)]);
+    $request = new UserRequest();
+
+    $response = $request->send($mockClient);
+
+    expect($response->body())->toEqual('');
+});


### PR DESCRIPTION
Fixes #213 

This PR fixes an issue with v1's mock responses if you were to use `null` as the data of the mock response, it would throw an exception. 