### PR TITLE
Make it possible to obfuscate e-mails in recorded fixtures

### DIFF
--- a/src/Data/RecordedResponse.php
+++ b/src/Data/RecordedResponse.php
@@ -7,6 +7,8 @@ namespace Saloon\Data;
 use JsonSerializable;
 use Saloon\Contracts\Response;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Helpers\Str;
+use Saloon\Helpers\MockConfig;
 
 class RecordedResponse implements JsonSerializable
 {
@@ -67,7 +69,7 @@ class RecordedResponse implements JsonSerializable
         return new static(
             statusCode: $response->status(),
             headers: $response->headers()->all(),
-            data: $response->body(),
+            data: MockConfig::shouldObfuscateEmails() ? Str::obfuscateEmail($response->body()) : $response->body(),
         );
     }
 

--- a/src/Helpers/MockConfig.php
+++ b/src/Helpers/MockConfig.php
@@ -21,6 +21,13 @@ final class MockConfig
     private static bool $throwOnMissingFixtures = false;
 
     /**
+     * Denotes if e-mails in responses should be obfuscated when recording fixtures.
+     *
+     * @var bool
+     */
+    private static bool $obfuscateEmails = false;
+
+    /**
      * Set the fixture path
      *
      * @param string $path
@@ -59,5 +66,25 @@ final class MockConfig
     public static function isThrowingOnMissingFixtures(): bool
     {
         return self::$throwOnMissingFixtures;
+    }
+
+    /**
+     * Obfuscate e-mails in responses when recording fixtures
+     *
+     * @return void
+     */
+    public static function obfuscateEmails(): void
+    {
+        self::$obfuscateEmails = true;
+    }
+
+    /**
+     * Should we obfuscate e-mails in fixtures?
+     *
+     * @return bool
+     */
+    public static function shouldObfuscateEmails(): bool
+    {
+        return self::$obfuscateEmails;
     }
 }

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -102,4 +102,28 @@ class Str
 
         return $string;
     }
+    
+    // Sources
+    // https://stackoverflow.com/questions/68639402/looking-for-regex-to-obfuscate-email-to-tw-de
+    // https://github.com/gremo/email-obfuscator
+    public static function obfuscateEmails($string)
+    {
+        $patterns = array(
+            '|[_a-z0-9-]+(?:\.[_a-z0-9-]+)*@[a-z0-9-]+(?:\.[a-z0-9-]+)*(?:\.[a-z]{2,3})|i', // plain emails
+        );
+
+        foreach ($patterns as $pattern) {
+            $string = preg_replace_callback($pattern, function ($parts) {
+                // Clean up element parts.
+                $parts = array_map('trim', $parts);
+
+                $obfuscate_pattern = "/^\w\K[^\s@]+@(\w)[^\s.@]+/";
+                $replacement = "*@$1***";
+                return preg_replace($obfuscate_pattern, $replacement, $parts[0]);
+
+            }, $string);
+        }
+
+        return $string;
+    }    
 }


### PR DESCRIPTION
Hi

I have just started using Saloon for a project. I noticed that when recording data from API's it would save personal data such as e-mail addresses in the fixtures. This is not always ideal in terms of data security or law (especially in Europa). 

If I fetch a data set containing e-mail addresses which I then commit to Github then I have personal identifiable information in my Github Repo. 

A solution could be to ignore the fixtures and not commit them to Github, but I have tried to make a proof of concept where I obfuscate e-mails.

I have added the following to MockConfig
```php
MockConfig::obfuscateEmails()
```

When this is called it will obfuscate e-mails in fixtures like this:

Before
```json
{
    "users" : [
        {
          "name": "Cristiano Ronaldo",
          "e-mail": "cristiano@example.com"
        },
        {
          "name": "Lionel Messi",
          "e-mail": "lionel@example.com"
        }
    ]
}
```

After
```json
{
    "users" : [
        {
          "name": "Cristiano Ronaldo",
          "e-mail": "c*@e***.com"
        },
        {
          "name": "Lionel Messi",
          "e-mail": "l*@e***.com"
        }
    ]
}
```

I am not sure this is ready for production, but what do you think about something like this?