### PR TITLE
Fix | Unset the sender when serializing

### DIFF
--- a/src/Http/Connector.php
+++ b/src/Http/Connector.php
@@ -37,4 +37,16 @@ abstract class Connector implements ConnectorContract, HasDebuggingContract
     use HasPool;
     use HasDelay;
     use HasDebugging;
+
+    /**
+     * Handle serializing
+     *
+     * @return array
+     */
+    public function __sleep(): array
+    {
+        $this->destroySender();
+
+        return array_keys(get_object_vars($this));
+    }
 }

--- a/src/Traits/Connector/HasSender.php
+++ b/src/Traits/Connector/HasSender.php
@@ -34,6 +34,18 @@ trait HasSender
     }
 
     /**
+     * Unset the sender
+     *
+     * @return $this
+     */
+    public function destroySender(): static
+    {
+        unset($this->sender);
+
+        return $this;
+    }
+
+    /**
      * Define the default request sender.
      *
      * @return \Saloon\Contracts\Sender

--- a/tests/Unit/ConnectorTest.php
+++ b/tests/Unit/ConnectorTest.php
@@ -6,6 +6,7 @@ use Saloon\Http\Response;
 use GuzzleHttp\Promise\Promise;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\Senders\GuzzleSender;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Tests\Fixtures\Requests\HasConnectorUserRequest;
@@ -55,4 +56,19 @@ test('you can send an asynchronous request through the connector', function () {
 
     expect($response)->toBeInstanceOf(Response::class);
     expect($response->json())->toEqual(['name' => 'Sammyjo20', 'actual_name' => 'Sam Carré', 'twitter' => '@carre_sam']);
+});
+
+test('when serializing a connector the sender is unset', function () {
+    $connector = new TestConnector;
+    $sender = $connector->sender();
+
+    $destroyedSenderConnector = clone $connector;
+    $destroyedSenderConnector->destroySender();
+
+    expect($sender)->toBeInstanceOf(GuzzleSender::class);
+
+    $serialized = serialize($connector);
+
+    expect($serialized)->toBeString();
+    expect(unserialize($serialized))->toEqual($destroyedSenderConnector);
 });

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -61,3 +61,16 @@ test('it will throw an exception if the sender does not implement the sender int
 
     $connector->sender();
 });
+
+test('the sender can be destroyed', function () {
+    $connector = new TestConnector();
+    $senderA = $connector->sender();
+
+    expect($senderA)->toBe($connector->sender());
+
+    $connector->destroySender();
+
+    $senderB = $connector->sender();
+
+    expect($senderA)->not->toBe($senderB);
+});


### PR DESCRIPTION
This PR introduces a `__sleep()` function on the connector which will destroy the sender instance when attempting to serialize. This is because any open connections that a sender may have must be removed when serializing. 

There was an issue where if the sender was used, then you wouldn't be able to serialize the sender because Guzzle uses closures inside of its handlers.