### PR TITLE
Feature | Ability to overwrite OAuth2 request classes

### DIFF
--- a/src/Traits/OAuth2/ClientCredentialsGrant.php
+++ b/src/Traits/OAuth2/ClientCredentialsGrant.php
@@ -6,7 +6,9 @@ namespace Saloon\Traits\OAuth2;
 
 use DateTimeImmutable;
 use Saloon\Helpers\Date;
+use Saloon\Contracts\Request;
 use Saloon\Contracts\Response;
+use Saloon\Helpers\OAuth2\OAuthConfig;
 use Saloon\Contracts\OAuthAuthenticator;
 use Saloon\Http\Auth\AccessTokenAuthenticator;
 use Saloon\Http\OAuth2\GetClientCredentialsTokenRequest;
@@ -34,7 +36,7 @@ trait ClientCredentialsGrant
     {
         $this->oauthConfig()->validate(withRedirectUrl: false);
 
-        $request = new GetClientCredentialsTokenRequest($this->oauthConfig(), $scopes, $scopeSeparator);
+        $request = $this->resolveAccessTokenRequest($this->oauthConfig(), $scopes, $scopeSeparator);
 
         $request = $this->oauthConfig()->invokeRequestModifier($request);
 
@@ -79,5 +81,18 @@ trait ClientCredentialsGrant
     protected function createOAuthAuthenticator(string $accessToken, ?DateTimeImmutable $expiresAt = null): OAuthAuthenticator
     {
         return new AccessTokenAuthenticator($accessToken, null, $expiresAt);
+    }
+
+    /**
+     * Resolve the access token request
+     *
+     * @param OAuthConfig $oauthConfig
+     * @param array $scopes
+     * @param string $scopeSeparator
+     * @return Request
+     */
+    protected function resolveAccessTokenRequest(OAuthConfig $oauthConfig, array $scopes = [], string $scopeSeparator = ' '): Request
+    {
+        return new GetClientCredentialsTokenRequest($oauthConfig, $scopes, $scopeSeparator);
     }
 }

--- a/tests/Feature/Oauth2/ClientCredentialsFlowConnectorTest.php
+++ b/tests/Feature/Oauth2/ClientCredentialsFlowConnectorTest.php
@@ -10,6 +10,8 @@ use Saloon\Http\Auth\AccessTokenAuthenticator;
 use Saloon\Exceptions\OAuthConfigValidationException;
 use Saloon\Tests\Fixtures\Connectors\ClientCredentialsConnector;
 use Saloon\Tests\Fixtures\Connectors\NoConfigClientCredentialsConnector;
+use Saloon\Tests\Fixtures\Connectors\CustomRequestClientCredentialsConnector;
+use Saloon\Tests\Fixtures\Requests\OAuth\CustomClientCredentialsAccessTokenRequest;
 
 test('you can get the authenticator from the connector', function () {
     $mockClient = new MockClient([
@@ -180,4 +182,17 @@ test('if you attempt to use the client credentials flow without a secret it will
     $this->expectExceptionMessage('The Client Secret is empty or has not been provided.');
 
     $connector->getAccessToken();
+});
+
+test('on the connector you can overwrite the getAccessToken request', function () {
+    $mockClient = new MockClient([
+        CustomClientCredentialsAccessTokenRequest::class => MockResponse::make(['access_token' => 'access', 'expires_in' => 3600], 200),
+    ]);
+
+    $connector = new CustomRequestClientCredentialsConnector();
+    $connector->withMockClient($mockClient);
+
+    $accessTokenResponse = $connector->getAccessToken(returnResponse: true);
+
+    expect($accessTokenResponse->getRequest())->toBeInstanceOf(CustomClientCredentialsAccessTokenRequest::class);
 });

--- a/tests/Fixtures/Connectors/CustomRequestClientCredentialsConnector.php
+++ b/tests/Fixtures/Connectors/CustomRequestClientCredentialsConnector.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Connectors;
+
+use Saloon\Contracts\Request;
+use Saloon\Helpers\OAuth2\OAuthConfig;
+use Saloon\Tests\Fixtures\Requests\OAuth\CustomClientCredentialsAccessTokenRequest;
+
+class CustomRequestClientCredentialsConnector extends ClientCredentialsConnector
+
+    /**
+     * Resolve the access token request
+     *
+     * @param OAuthConfig $oauthConfig
+     * @param array $scopes
+     * @param string $scopeSeparator
+     * @return Request
+     */
+{
+    protected function resolveAccessTokenRequest(OAuthConfig $oauthConfig, array $scopes = [], string $scopeSeparator = ' '): Request
+    {
+        return new CustomClientCredentialsAccessTokenRequest($oauthConfig, $scopes, $scopeSeparator);
+    }
+}

--- a/tests/Fixtures/Connectors/CustomRequestOAuth2Connector.php
+++ b/tests/Fixtures/Connectors/CustomRequestOAuth2Connector.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Connectors;
+
+use Saloon\Http\Connector;
+use Saloon\Contracts\Request;
+use Saloon\Helpers\OAuth2\OAuthConfig;
+use Saloon\Traits\OAuth2\AuthorizationCodeGrant;
+use Saloon\Tests\Fixtures\Requests\OAuth\CustomOAuthUserRequest;
+use Saloon\Tests\Fixtures\Requests\OAuth\CustomAccessTokenRequest;
+use Saloon\Tests\Fixtures\Requests\OAuth\CustomRefreshTokenRequest;
+
+class CustomRequestOAuth2Connector extends Connector
+{
+    use AuthorizationCodeGrant;
+
+    /**
+     * Define the base URL.
+     *
+     * @return string
+     */
+    public function resolveBaseUrl(): string
+    {
+        return 'https://oauth.saloon.dev';
+    }
+
+    /**
+     * Define default Oauth config.
+     *
+     * @return OAuthConfig
+     */
+    protected function defaultOauthConfig(): OAuthConfig
+    {
+        return OAuthConfig::make()
+            ->setClientId('client-id')
+            ->setClientSecret('client-secret')
+            ->setRedirectUri('https://my-app.saloon.dev/auth/callback');
+    }
+
+    /**
+     * Resolve the access token request
+     *
+     * @param string $code
+     * @param OAuthConfig $oauthConfig
+     * @return Request
+     */
+    protected function resolveAccessTokenRequest(string $code, OAuthConfig $oauthConfig): Request
+    {
+        return new CustomAccessTokenRequest($code, $oauthConfig);
+    }
+
+    /**
+     * Resolve the refresh token request
+     *
+     * @param OAuthConfig $oauthConfig
+     * @param string $refreshToken
+     * @return Request
+     */
+    protected function resolveRefreshTokenRequest(OAuthConfig $oauthConfig, string $refreshToken): Request
+    {
+        return new CustomRefreshTokenRequest($oauthConfig, $refreshToken);
+    }
+
+    /**
+     * Resolve the user request
+     *
+     * @param OAuthConfig $oauthConfig
+     * @return Request
+     */
+    protected function resolveUserRequest(OAuthConfig $oauthConfig): Request
+    {
+        return new CustomOAuthUserRequest($oauthConfig);
+    }
+}

--- a/tests/Fixtures/Requests/OAuth/CustomAccessTokenRequest.php
+++ b/tests/Fixtures/Requests/OAuth/CustomAccessTokenRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests\OAuth;
+
+use Saloon\Http\OAuth2\GetAccessTokenRequest;
+
+class CustomAccessTokenRequest extends GetAccessTokenRequest
+{
+    //
+}

--- a/tests/Fixtures/Requests/OAuth/CustomClientCredentialsAccessTokenRequest.php
+++ b/tests/Fixtures/Requests/OAuth/CustomClientCredentialsAccessTokenRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests\OAuth;
+
+use Saloon\Http\OAuth2\GetClientCredentialsTokenRequest;
+
+class CustomClientCredentialsAccessTokenRequest extends GetClientCredentialsTokenRequest
+{
+    //
+}

--- a/tests/Fixtures/Requests/OAuth/CustomOAuthUserRequest.php
+++ b/tests/Fixtures/Requests/OAuth/CustomOAuthUserRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests\OAuth;
+
+use Saloon\Http\OAuth2\GetUserRequest;
+
+class CustomOAuthUserRequest extends GetUserRequest
+{
+    //
+}

--- a/tests/Fixtures/Requests/OAuth/CustomRefreshTokenRequest.php
+++ b/tests/Fixtures/Requests/OAuth/CustomRefreshTokenRequest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests\OAuth;
+
+use Saloon\Http\OAuth2\GetRefreshTokenRequest;
+
+class CustomRefreshTokenRequest extends GetRefreshTokenRequest
+{
+    //
+}


### PR DESCRIPTION
Fixes #239

This PR adds a few overwritable protected methods on the `AuthorizationCodeGrant` and `ClientCredentialsGrant` OAuth2 traits. These methods will allow you to overwrite the instantiation of the request classes yourself, so if you need to completely swap the classes out to your own requests, you can now do it.

With future versions of Saloon, I think this should be the preferred way of modifying the request classes, including adding query parameters or changing the request body, because now we have multiple ways of modifying the requests and it may get a little confusing.