### PR TITLE
[WIP] Update Storage.php

### DIFF
--- a/src/Helpers/Storage.php
+++ b/src/Helpers/Storage.php
@@ -31,7 +31,7 @@ class Storage
             $createMissingBaseDirectory ? $this->createDirectory($baseDirectory) : throw new DirectoryNotFoundException($baseDirectory);
         }
 
-        $this->baseDirectory = $baseDirectory;
+        $this->baseDirectory = base_path($baseDirectory);
     }
 
     /**

--- a/src/Helpers/Storage.php
+++ b/src/Helpers/Storage.php
@@ -31,7 +31,9 @@ class Storage
             $createMissingBaseDirectory ? $this->createDirectory($baseDirectory) : throw new DirectoryNotFoundException($baseDirectory);
         }
 
-        $this->baseDirectory = base_path($baseDirectory);
+        $this->baseDirectory = class_exists(\Saloon\Laravel\Saloon::class) && function_exists('base_path') 
+            ? base_path($baseDirectory) 
+            : $baseDirectory;
     }
 
     /**


### PR DESCRIPTION
Add `base_path` to the storage helper to prevent overspilling into the public directory.

Sorts #245 if needed.

Obviously the downside to this is that you can only use directories within your laravel base install, depends if that's an okay trade off.