### PR TITLE
Feature | Added `SoapClientSender`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "php": "^8.1",
         "guzzlehttp/guzzle": "^7.5",
         "guzzlehttp/promises": "^1.5 || ^2.0",
-        "psr/http-message": "^1.1 || ^2.0"
+        "psr/http-message": "^1.1 || ^2.0",
+        "ext-soap": "*"
     },
     "require-dev": {
         "ext-simplexml": "*",

--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -46,21 +46,6 @@ parameters:
 			path: src/Http/PendingRequest.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of function call_user_func_array expects callable\\(\\)\\: mixed, \\(callable\\(\\)\\: mixed\\)\\|object given\\.$#"
-			count: 2
-			path: src/Http/Response.php
-
-		-
-			message: "#^Parameter \\#1 \\$object of method ReflectionMethod\\:\\:invoke\\(\\) expects object\\|null, object\\|string given\\.$#"
-			count: 1
-			path: src/Http/Response.php
-
-		-
-			message: "#^Parameter \\#1 \\$objectOrClass of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, object\\|string given\\.$#"
-			count: 1
-			path: src/Http/Response.php
-
-		-
 			message: "#^Method Saloon\\\\Http\\\\Senders\\\\GuzzleSender\\:\\:createRequestOptions\\(\\) should return array\\<'allow_redirects'\\|'auth'\\|'body'\\|'cert'\\|'connect_timeout'\\|'cookies'\\|'crypto_method'\\|'debug'\\|'decode_content'\\|'delay'\\|'expect'\\|'force_ip_resolve'\\|'form_params'\\|'headers'\\|'http_errors'\\|'idn_conversion'\\|'json'\\|'multipart'\\|'on_headers'\\|'on_stats'\\|'progress'\\|'proxy'\\|'query'\\|'read_timeout'\\|'sink'\\|'ssl_key'\\|'stream'\\|'synchronous'\\|'timeout'\\|'verify'\\|'version', mixed\\> but returns array\\<string, mixed\\>\\.$#"
 			count: 2
 			path: src/Http/Senders/GuzzleSender.php

--- a/src/Contracts/HttpResponse.php
+++ b/src/Contracts/HttpResponse.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Contracts;
+
+use Throwable;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface HttpResponse extends Response
+{
+    /**
+     * Create an instance of the response from a PSR response
+     *
+     * @param \Saloon\Contracts\PendingRequest $pendingRequest
+     * @param \Psr\Http\Message\ResponseInterface $psrResponse
+     * @param \Throwable|null $senderException
+     * @return $this
+     */
+    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, ?Throwable $senderException = null): static;
+
+    /**
+     * Create a PSR response from the raw response.
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function getPsrResponse(): ResponseInterface;
+
+    /**
+     * Get the body as a stream. Don't forget to close the stream after using ->close().
+     *
+     * @return \Psr\Http\Message\StreamInterface
+     */
+    public function stream(): StreamInterface;
+
+    /**
+     * Close the stream and any underlying resources.
+     *
+     * @return $this
+     */
+    public function close(): static;
+}

--- a/src/Contracts/Response.php
+++ b/src/Contracts/Response.php
@@ -7,28 +7,9 @@ namespace Saloon\Contracts;
 use Throwable;
 use SimpleXMLElement;
 use Illuminate\Support\Collection;
-use Psr\Http\Message\StreamInterface;
-use Psr\Http\Message\ResponseInterface;
 
 interface Response extends HasHeaders
 {
-    /**
-     * Create an instance of the response from a PSR response
-     *
-     * @param \Saloon\Contracts\PendingRequest $pendingRequest
-     * @param \Psr\Http\Message\ResponseInterface $psrResponse
-     * @param \Throwable|null $senderException
-     * @return $this
-     */
-    public static function fromPsrResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, ?Throwable $senderException = null): static;
-
-    /**
-     * Create a PSR response from the raw response.
-     *
-     * @return \Psr\Http\Message\ResponseInterface
-     */
-    public function getPsrResponse(): ResponseInterface;
-
     /**
      * Get the underlying PendingRequest that created the response
      *
@@ -42,20 +23,6 @@ interface Response extends HasHeaders
      * @return string
      */
     public function body(): string;
-
-    /**
-     * Get the body as a stream. Don't forget to close the stream after using ->close().
-     *
-     * @return \Psr\Http\Message\StreamInterface
-     */
-    public function stream(): StreamInterface;
-
-    /**
-     * Close the stream and any underlying resources.
-     *
-     * @return $this
-     */
-    public function close(): static;
 
     /**
      * Get a header from the response.

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -17,6 +17,7 @@ use Saloon\Traits\Conditionable;
 use Saloon\Traits\HasMockClient;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Contracts\Authenticator;
+use Saloon\Http\Responses\Response;
 use Saloon\Helpers\ReflectionHelper;
 use GuzzleHttp\Promise\PromiseInterface;
 use Saloon\Http\Middleware\DebugRequest;

--- a/src/Http/Responses/Response.php
+++ b/src/Http/Responses/Response.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http;
+namespace Saloon\Http\Responses;
 
 use Throwable;
 use Saloon\Traits\Macroable;

--- a/src/Http/Responses/Response.php
+++ b/src/Http/Responses/Response.php
@@ -126,6 +126,18 @@ class Response implements HttpResponseContract
     }
 
     /**
+     * Close the stream and any underlying resources.
+     *
+     * @return $this
+     */
+    public function close(): static
+    {
+        $this->stream()->close();
+
+        return $this;
+    }
+
+    /**
      * Get the headers from the response.
      *
      * @return \Saloon\Contracts\ArrayStore

--- a/src/Http/Responses/Response.php
+++ b/src/Http/Responses/Response.php
@@ -12,10 +12,10 @@ use Saloon\Contracts\PendingRequest;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\ResponseInterface;
 use Saloon\Traits\Responses\HasResponseHelpers;
-use Saloon\Contracts\Response as ResponseContract;
 use Saloon\Contracts\ArrayStore as ArrayStoreContract;
+use Saloon\Contracts\HttpResponse as HttpResponseContract;
 
-class Response implements ResponseContract
+class Response implements HttpResponseContract
 {
     use Macroable;
     use HasResponseHelpers;

--- a/src/Http/Responses/SoapResponse.php
+++ b/src/Http/Responses/SoapResponse.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Http\Responses;
+
+use Throwable;
+use SoapClient;
+use Saloon\Traits\Macroable;
+use Saloon\Contracts\Request;
+use Saloon\Repositories\ArrayStore;
+use Saloon\Contracts\PendingRequest;
+use Saloon\Traits\Responses\HasResponseHelpers;
+use Saloon\Contracts\Response as ResponseContract;
+use Saloon\Contracts\ArrayStore as ArrayStoreContract;
+
+class SoapResponse implements ResponseContract
+{
+    use Macroable;
+    use HasResponseHelpers;
+
+    /**
+     * Create a new response instance.
+     *
+     * @param \SoapClient $client
+     * @param mixed $response
+     * @param PendingRequest $pendingRequest
+     * @param \Throwable|null $senderException
+     */
+    public function __construct(protected SoapClient $client, protected mixed $response, protected PendingRequest $pendingRequest, protected ?Throwable $senderException = null)
+    {
+    }
+
+    /**
+     * Get the headers from the response.
+     *
+     * @return \Saloon\Contracts\ArrayStore
+     */
+    public function headers(): ArrayStoreContract
+    {
+        $responseHeaders = $this->client->__getLastResponseHeaders();
+        preg_match_all('/(.*?):\s(.*?)\r\n/', $responseHeaders, $matches);
+
+        $headers = [];
+        if (count($matches) === 3) {
+            $headers = array_combine($matches[1], $matches[2]);
+        }
+
+        return new ArrayStore($headers);
+    }
+
+    /**
+     * Get the pending request that created the response.
+     *
+     * @return \Saloon\Contracts\PendingRequest
+     */
+    public function getPendingRequest(): PendingRequest
+    {
+        return $this->pendingRequest;
+    }
+
+    /**
+     * Get the body of the response as string.
+     *
+     * @return string
+     */
+    public function body(): string
+    {
+        return (string) json_encode($this->response);
+    }
+
+    /**
+     * Get the status code of the response.
+     *
+     * @return int
+     */
+    public function status(): int
+    {
+        return 200;
+    }
+
+    /**
+     * Get the original request that created the response.
+     *
+     * @return \Saloon\Contracts\Request
+     */
+    public function getRequest(): Request
+    {
+        return $this->pendingRequest->getRequest();
+    }
+
+    /**
+     * Get the original sender exception
+     *
+     * @return \Throwable|null
+     */
+    public function getSenderException(): ?Throwable
+    {
+        return $this->senderException;
+    }
+}

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -19,11 +19,11 @@ use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\TransferException;
 use Saloon\Repositories\Body\FormBodyRepository;
 use Saloon\Repositories\Body\JsonBodyRepository;
-use Saloon\Contracts\Response as ResponseContract;
 use Saloon\Repositories\Body\StreamBodyRepository;
 use Saloon\Repositories\Body\StringBodyRepository;
 use Saloon\Exceptions\Request\FatalRequestException;
 use Saloon\Repositories\Body\MultipartBodyRepository;
+use Saloon\Contracts\HttpResponse as HttpResponseContract;
 
 class GuzzleSender implements Sender
 {
@@ -82,11 +82,11 @@ class GuzzleSender implements Sender
      *
      * @param \Saloon\Contracts\PendingRequest $pendingRequest
      * @param bool $asynchronous
-     * @return \Saloon\Contracts\Response|\GuzzleHttp\Promise\PromiseInterface
+     * @return \Saloon\Contracts\HttpResponse|\GuzzleHttp\Promise\PromiseInterface
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Saloon\Exceptions\Request\FatalRequestException
      */
-    public function sendRequest(PendingRequest $pendingRequest, bool $asynchronous = false): ResponseContract|PromiseInterface
+    public function sendRequest(PendingRequest $pendingRequest, bool $asynchronous = false): HttpResponseContract|PromiseInterface
     {
         return $asynchronous === true
             ? $this->sendAsynchronousRequest($pendingRequest)
@@ -97,11 +97,11 @@ class GuzzleSender implements Sender
      * Send a synchronous request.
      *
      * @param \Saloon\Contracts\PendingRequest $pendingRequest
-     * @return \Saloon\Contracts\Response
+     * @return \Saloon\Contracts\HttpResponse
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Saloon\Exceptions\Request\FatalRequestException
      */
-    protected function sendSynchronousRequest(PendingRequest $pendingRequest): ResponseContract
+    protected function sendSynchronousRequest(PendingRequest $pendingRequest): HttpResponseContract
     {
         $guzzleRequest = $this->createGuzzleRequest($pendingRequest);
         $guzzleRequestOptions = $this->createRequestOptions($pendingRequest);
@@ -204,11 +204,11 @@ class GuzzleSender implements Sender
      * @param \Saloon\Contracts\PendingRequest $pendingSaloonRequest
      * @param \Psr\Http\Message\ResponseInterface $guzzleResponse
      * @param \Exception|null $exception
-     * @return \Saloon\Contracts\Response
+     * @return \Saloon\Contracts\HttpResponse
      */
-    protected function createResponse(PendingRequest $pendingSaloonRequest, ResponseInterface $guzzleResponse, Exception $exception = null): ResponseContract
+    protected function createResponse(PendingRequest $pendingSaloonRequest, ResponseInterface $guzzleResponse, Exception $exception = null): HttpResponseContract
     {
-        /** @var class-string<\Saloon\Contracts\Response> $responseClass */
+        /** @var class-string<\Saloon\Contracts\HttpResponse> $responseClass */
         $responseClass = $pendingSaloonRequest->getResponseClass();
 
         return $responseClass::fromPsrResponse($guzzleResponse, $pendingSaloonRequest, $exception);

--- a/src/Http/Senders/SimulatedSender.php
+++ b/src/Http/Senders/SimulatedSender.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Promise\RejectedPromise;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Saloon\Contracts\SimulatedResponsePayload;
-use Saloon\Contracts\Response as ResponseContract;
+use Saloon\Contracts\HttpResponse as HttpResponseContract;
 
 class SimulatedSender implements Sender
 {
@@ -22,11 +22,11 @@ class SimulatedSender implements Sender
      *
      * @param \Saloon\Contracts\PendingRequest $pendingRequest
      * @param bool $asynchronous
-     * @return \Saloon\Contracts\Response|\GuzzleHttp\Promise\PromiseInterface
+     * @return \Saloon\Contracts\HttpResponse|\GuzzleHttp\Promise\PromiseInterface
      * @throws \Saloon\Exceptions\SenderException
      * @throws \Throwable
      */
-    public function sendRequest(PendingRequest $pendingRequest, bool $asynchronous = false): ResponseContract|PromiseInterface
+    public function sendRequest(PendingRequest $pendingRequest, bool $asynchronous = false): HttpResponseContract|PromiseInterface
     {
         $simulatedResponsePayload = $pendingRequest->getSimulatedResponsePayload();
 
@@ -45,7 +45,7 @@ class SimulatedSender implements Sender
 
         // Let's create our response!
 
-        /** @var class-string<\Saloon\Contracts\Response> $responseClass */
+        /** @var class-string<\Saloon\Contracts\HttpResponse> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();
 
         $response = $responseClass::fromPsrResponse(

--- a/src/Http/Senders/SoapClientSender.php
+++ b/src/Http/Senders/SoapClientSender.php
@@ -34,7 +34,7 @@ class SoapClientSender implements Sender
 
             $this->client ??= new SoapClient(
                 wsdl: $pendingRequest->getConnector()->resolveBaseUrl(),
-                options: $pendingRequest->config()->all()
+                options: $pendingRequest->config()->add('trace', 1)->all()
             );
 
             $this->client->__setSoapHeaders($this->headers);

--- a/src/Http/Senders/SoapClientSender.php
+++ b/src/Http/Senders/SoapClientSender.php
@@ -96,4 +96,15 @@ class SoapClientSender implements Sender
             senderException: $exception
         );
     }
+
+
+    /**
+     * Get the Soap client
+     *
+     * @return \SoapClient
+     */
+    public function getSoapClient(): SoapClient
+    {
+        return $this->client;
+    }
 }

--- a/src/Http/Senders/SoapClientSender.php
+++ b/src/Http/Senders/SoapClientSender.php
@@ -107,4 +107,14 @@ class SoapClientSender implements Sender
     {
         return $this->client;
     }
+
+    /**
+     * Get the Soap headers
+     *
+     * @return array<SoapHeader>
+     */
+    public function getSoapHeaders(): array
+    {
+        return $this->headers;
+    }
 }

--- a/src/Http/Senders/SoapClientSender.php
+++ b/src/Http/Senders/SoapClientSender.php
@@ -22,6 +22,9 @@ class SoapClientSender implements Sender
      */
     public SoapClient $client;
 
+    /**
+     * @var array<SoapHeader>
+     */
     public array $headers;
 
     /**
@@ -59,8 +62,8 @@ class SoapClientSender implements Sender
     /**
      * Build up all the request headers
      *
-     * @param \Saloon\Contracts\PendingRequest $pendingRequest
-     * @return array<SoapHeader>
+     * @param PendingRequest $pendingRequest
+     * @return void
      */
     protected function createRequestHeaders(PendingRequest $pendingRequest): void
     {

--- a/src/Http/Senders/SoapClientSender.php
+++ b/src/Http/Senders/SoapClientSender.php
@@ -66,7 +66,9 @@ class SoapClientSender implements Sender
     {
         $headers = [];
         foreach ($pendingRequest->headers()->all() as $namespace => $value) {
-            if (is_array($value)) {
+            if ($value instanceof SoapHeader) {
+                $headers[] = $value;
+            } elseif (is_array($value)) {
                 $headers[] = new SoapHeader(
                     namespace: $namespace,
                     name: ! empty($value[0]) ? $value[0] : '',

--- a/src/Traits/Responses/HasResponseHelpers.php
+++ b/src/Traits/Responses/HasResponseHelpers.php
@@ -329,18 +329,6 @@ trait HasResponseHelpers
     }
 
     /**
-     * Close the stream and any underlying resources.
-     *
-     * @return $this
-     */
-    public function close(): static
-    {
-        $this->stream()->close();
-
-        return $this;
-    }
-
-    /**
      * Get the body of the response.
      *
      * @return string

--- a/tests/Feature/AsyncRequestTest.php
+++ b/tests/Feature/AsyncRequestTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use GuzzleHttp\Promise\PromiseInterface;
 use Saloon\Tests\Fixtures\Responses\UserData;

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
 use Saloon\Helpers\MockConfig;
 use Saloon\Http\PendingRequest;
 use League\Flysystem\Filesystem;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Exceptions\Request\RequestException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;

--- a/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
+++ b/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 use Saloon\Helpers\Str;
 use Saloon\Helpers\Date;
-use Saloon\Http\Response;
 use Saloon\Contracts\Request;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\OAuth2\GetUserRequest;
 use Saloon\Exceptions\InvalidStateException;

--- a/tests/Feature/PoolTest.php
+++ b/tests/Feature/PoolTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Exception\ConnectException;

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Responses\Response;
 use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Http\Responses\SoapResponse;
+use Saloon\Tests\Fixtures\Requests\SoapRequest;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Connectors\SoapClientConnector;
 use Saloon\Tests\Fixtures\Requests\HasConnectorUserRequest;
 
 test('a request can be made successfully', function () {
@@ -25,6 +28,22 @@ test('a request can be made successfully', function () {
         'name' => 'Sammyjo20',
         'actual_name' => 'Sam',
         'twitter' => '@carre_sam',
+    ]);
+});
+
+test('a soap request can be made successfully', function () {
+    $connector = new SoapClientConnector();
+    $response = $connector->send(new SoapRequest(fahrenheit: 1));
+
+    $data = $response->json();
+
+    expect($response->getPendingRequest()->isAsynchronous())->toBeFalse();
+    expect($response)->toBeInstanceOf(SoapResponse::class);
+    expect($response->isMocked())->toBeFalse();
+    expect($response->status())->toEqual(200);
+
+    expect($data)->toEqual([
+        'FahrenheitToCelsiusResult' => '-17.2222222222222',
     ]);
 });
 

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Senders\GuzzleSender;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;

--- a/tests/Feature/SoapClientSenderTest.php
+++ b/tests/Feature/SoapClientSenderTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\Http\Senders\SoapClientSender;
+use Saloon\Tests\Fixtures\Requests\SoapRequest;
+use Saloon\Tests\Fixtures\Connectors\SoapClientConnector;
+
+test('the soap sender will send to the right url using the correct method', function () {
+    $connector = new SoapClientConnector();
+    $request = new SoapRequest(fahrenheit: 1);
+
+    /** @var SoapClientSender $sender */
+    $sender = $connector->sender();
+
+    $pendingRequest = $connector->createPendingRequest($request);
+
+    $connector->send($request);
+
+    $client = $sender->getSoapClient();
+
+    expect($client->__getLastRequestHeaders())
+        ->toContain($pendingRequest->getMethod()->value)
+        ->toContain(parse_url(wsdlUrl(), PHP_URL_PATH))
+        ->toContain($pendingRequest->getRequest()->resolveEndpoint());
+});
+
+test('the soap sender will send all headers, query parameters and config', function () {
+    $connector = new SoapClientConnector();
+    $request = new SoapRequest(fahrenheit: 1);
+
+    /** @var SoapClientSender $sender */
+    $sender = $connector->sender();
+
+    $pendingRequest = $connector->createPendingRequest($request);
+
+    $connector->send($request);
+
+    $client = $sender->getSoapClient();
+
+    $headerXmlString = '';
+    $index = 2;
+    foreach ($sender->getSoapHeaders() as $header) {
+        $tag = "ns$index:{$header->name}";
+        if ($header->data) {
+            $headerXmlString .= "<$tag>{$header->data}</$tag>";
+        } else {
+            $headerXmlString .= "<$tag/>";
+        }
+
+        $index++;
+    }
+
+    $bodyXmlString = '';
+    $index = 1;
+    foreach ($pendingRequest->getRequest()->query()->all() as $name => $value) {
+        $tag = "ns$index:$name";
+        $bodyXmlString .= "<$tag>{$value}</$tag>";
+        $index++;
+    }
+
+    expect($client->__getLastRequest())
+        ->toContain($headerXmlString)
+        ->toContain($bodyXmlString);
+
+    expect($client->__getLastRequestHeaders())
+        ->toContain('Test');
+});

--- a/tests/Feature/SoloRequestTest.php
+++ b/tests/Feature/SoloRequestTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
+use Saloon\Http\Responses\Response;
 use GuzzleHttp\Promise\PromiseInterface;
 use Saloon\Exceptions\Request\RequestException;
 use Saloon\Tests\Fixtures\Requests\SoloUserRequest;

--- a/tests/Fixtures/Connectors/SoapClientConnector.php
+++ b/tests/Fixtures/Connectors/SoapClientConnector.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Connectors;
+
+use Saloon\Http\Connector;
+use Saloon\Http\Senders\SoapClientSender;
+
+class SoapClientConnector extends Connector
+{
+
+    protected string $defaultSender = SoapClientSender::class;
+
+    /**
+     * Define the base url of the api.
+     *
+     * @return string
+     */
+    public function resolveBaseUrl(): string
+    {
+        return wsdlUrl();
+    }
+}

--- a/tests/Fixtures/Data/User.php
+++ b/tests/Fixtures/Data/User.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Data;
 
-use Saloon\Http\Response;
+use Saloon\Http\Responses\Response;
 
 class User
 {

--- a/tests/Fixtures/Requests/SoapRequest.php
+++ b/tests/Fixtures/Requests/SoapRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class SoapRequest extends Request
+{
+    protected Method $method = Method::POST;
+
+    /**
+     * Define the action for the request.
+     *
+     * @return string
+     */
+    public function resolveEndpoint(): string
+    {
+        return 'FahrenheitToCelsius';
+    }
+
+    protected function defaultQuery(): array
+    {
+        return [
+            'Fahrenheit' => $this->fahrenheit,
+        ];
+    }
+
+    public function __construct(public int $fahrenheit)
+    {
+        //
+    }
+}

--- a/tests/Fixtures/Requests/SoapRequest.php
+++ b/tests/Fixtures/Requests/SoapRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Requests;
 
+use SoapHeader;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -21,10 +22,46 @@ class SoapRequest extends Request
         return 'FahrenheitToCelsius';
     }
 
+    /**
+     * Default Query Parameters
+     *
+     * @return array<string, mixed>
+     */
     protected function defaultQuery(): array
     {
         return [
             'Fahrenheit' => $this->fahrenheit,
+        ];
+    }
+
+    /**
+     * Default Config
+     *
+     * @return array<string, mixed>
+     */
+    protected function defaultConfig(): array
+    {
+        return [
+            'connection_timeout' => 10, // in seconds,
+            'stream_context' => stream_context_create([
+                'http' => [
+                    'user_agent' => 'Test',
+                ],
+            ]),
+        ];
+    }
+
+    /**
+     * Define the soap headers that will be applied in every request.
+     *
+     * @return array<string, mixed>
+     */
+    protected function defaultHeaders(): array
+    {
+        return [
+            new SoapHeader(namespace: 'namespace1', name: 'name1', data: 'data1'),
+            'namespace2' => ['name2','data2', false, null],
+            'namespace3' => 'name3',
         ];
     }
 

--- a/tests/Fixtures/Responses/CustomResponse.php
+++ b/tests/Fixtures/Responses/CustomResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Responses;
 
-use Saloon\Http\Response;
+use Saloon\Http\Responses\Response;
 
 class CustomResponse extends Response
 {

--- a/tests/Fixtures/Responses/UserResponse.php
+++ b/tests/Fixtures/Responses/UserResponse.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Responses;
 
-use Saloon\Http\Response;
+use Saloon\Http\Responses\Response;
 
 class UserResponse extends Response
 {

--- a/tests/Fixtures/Senders/ArraySender.php
+++ b/tests/Fixtures/Senders/ArraySender.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Senders;
 
-use Saloon\Http\Response;
 use Saloon\Contracts\Sender;
+use Saloon\Http\Responses\Response;
 use Saloon\Contracts\PendingRequest;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -51,6 +51,11 @@ function apiUrl()
     return 'https://tests.saloon.dev/api';
 }
 
+function wsdlUrl()
+{
+    return 'https://www.w3schools.com/xml/tempconvert.asmx?WSDL';
+}
+
 function connector(): TestConnector
 {
     return new TestConnector;

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
 use Saloon\Helpers\Config;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\Senders\GuzzleSender;
 use Saloon\Tests\Fixtures\Senders\ArraySender;

--- a/tests/Unit/ConnectorTest.php
+++ b/tests/Unit/ConnectorTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
 use GuzzleHttp\Promise\Promise;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;

--- a/tests/Unit/MiddlewarePipelineTest.php
+++ b/tests/Unit/MiddlewarePipelineTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Helpers\MiddlewarePipeline;
 use Saloon\Tests\Fixtures\Requests\UserRequest;

--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use Saloon\Http\Request;
-use Saloon\Http\Response;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;

--- a/tests/Unit/MockResponseTest.php
+++ b/tests/Unit/MockResponseTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Saloon\Http\Response;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Responses\Response;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Responses\UserData;
 use Saloon\Tests\Fixtures\Requests\UserRequest;

--- a/tests/Unit/SaloonResponseTest.php
+++ b/tests/Unit/SaloonResponseTest.php
@@ -10,10 +10,10 @@ use Illuminate\Support\Collection;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Symfony\Component\DomCrawler\Crawler;
-use Saloon\Http\Response as SaloonResponse;
 use Saloon\Exceptions\Request\RequestException;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Http\Responses\Response as SaloonResponse;
 
 test('you can get the original pending request', function () {
     $mockClient = new MockClient([

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -3,9 +3,12 @@
 declare(strict_types=1);
 
 use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Http\Senders\SoapClientSender;
 use Saloon\Tests\Fixtures\Senders\ArraySender;
+use Saloon\Tests\Fixtures\Requests\SoapRequest;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Connectors\SoapClientConnector;
 use Saloon\Tests\Fixtures\Connectors\ArraySenderConnector;
 use Saloon\Tests\Fixtures\Connectors\ArraySenderDefaultMethodConnector;
 
@@ -34,6 +37,19 @@ test('you can overwrite the sender on a connector using the property', function 
 
     expect($response->headers()->all())->toEqual(['X-Fake' => true]);
     expect($response->body())->toEqual('Default');
+});
+
+test('you can overwrite the soap sender on a connector using the defaultSender method', function () {
+    $connector = new SoapClientConnector();
+    $sender = $connector->sender();
+
+    expect($sender)->toBeInstanceOf(SoapClientSender::class);
+    expect($connector->sender())->toBe($sender);
+
+    $request = new SoapRequest(fahrenheit: 1);
+    $response = $connector->send($request);
+
+    expect($response->body())->toEqual('{"FahrenheitToCelsiusResult":"-17.2222222222222"}');
 });
 
 test('you can overwrite the sender on a connector using the defaultSender method', function () {


### PR DESCRIPTION
This PR introduces a new sender type for Saloon's SOAP requests - `SoapClientSender`! With this, you will be able to specify a `SoapClient` request to be sent to your Web Services.

### Added 
- Added `HttpResponse` contract
- Added `SoapResponse`
- Added `ext-soap` dependency to `composer.json`
- Added `SoapClientSender`

### Changed
- Updated phpstan.baseline.neon
- Changed `ResponseContract` to `HttpResponseContract`
- Moved Response to Responses/Response
- Removed `close` method from `Response`

### Test
- Added `wsdlUrl()` function to Pest
- Added `SoapRequest` for test
- Added `SoapClientConnector` for test