### PR TITLE
Explicitly cast "expires_in" field to an integer

### DIFF
--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -173,7 +173,9 @@ trait AuthorizationCodeGrant
 
         $accessToken = $responseData->access_token;
         $refreshToken = $responseData->refresh_token ?? $fallbackRefreshToken;
-        $expiresAt = isset($responseData->expires_in) ? Date::now()->addSeconds($responseData->expires_in)->toDateTime() : null;
+        $expiresAt = isset($responseData->expires_in) && is_numeric($responseData->expires_in)
+            ? Date::now()->addSeconds((int) $responseData->expires_in)->toDateTime()
+            : null;
 
         return $this->createOAuthAuthenticator($accessToken, $refreshToken, $expiresAt);
     }

--- a/src/Traits/OAuth2/ClientCredentialsGrant.php
+++ b/src/Traits/OAuth2/ClientCredentialsGrant.php
@@ -66,7 +66,9 @@ trait ClientCredentialsGrant
         $responseData = $response->object();
 
         $accessToken = $responseData->access_token;
-        $expiresAt = isset($responseData->expires_in) ? Date::now()->addSeconds($responseData->expires_in)->toDateTime() : null;
+        $expiresAt = isset($responseData->expires_in) && is_numeric($responseData->expires_in)
+            ? Date::now()->addSeconds((int) $responseData->expires_in)->toDateTime()
+            : null;
 
         return $this->createOAuthAuthenticator($accessToken, $expiresAt);
     }


### PR DESCRIPTION
Hi 👋

This PR fixes an issue that might emerge when using `declare(strict_types=1)` in conjunction with an OAuth server that sends string values via the `expires_in` field instead of an integer.

As you may already know, PHP happily accepts values (type juggling) with the wrong type if `strict_types` is turned off, but fatally crashes if it's enabled.

I've added an extra `is_numeric` check just in case.

(FWIW, this happened to me using the `ClientCredentialsGrant`.)

Thanks 🙌