### PR TITLE
fixed: response body empty issue

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -106,13 +106,12 @@ class Response implements ResponseContract
     public function body(): string
     {
         $stream = $this->stream();
-        $body = $stream->getContents();
 
         if ($stream->isSeekable()) {
             $stream->rewind();
         }
 
-        return $body;
+        return $stream->getContents();
     }
 
     /**


### PR DESCRIPTION
## Issue

When I started using the `sammyjo20/saloon-laravel` package with Saloon, I can't get the response returned from API requests. `$response->body()` always returns an empty string.

When I examined it, I found that the problem was caused by the `body` method in the `Saloon\Http\Response` class. 

```php
public function body(): string
{
    $stream = $this->stream();
    $body = $stream->getContents();

    if ($stream->isSeekable()) {
        $stream->rewind();
    }

    return $body;
}
```

As you can see in the code above, first the response content is passed to the `$body` variable, then the pointer is rewinded with `$stream->rewind()`. It returns an empty string because the stream pointer is at the end of the stream (eof) position while the content is passed to the variable. 

## Solution
When I updated the code as below, I was able to get the data from the API response without any problem. After making this change, I ran the tests again and did not see any problems.

```php
public function body(): string
{
    $stream = $this->stream();

    if ($stream->isSeekable()) {
        $stream->rewind();
    }

    return $stream->getContents();
}
```

I hope this PR will be useful.