### PR TITLE
Add Query build utility on Guzzle request

### DIFF
--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -7,6 +7,7 @@ namespace Saloon\Http\Senders;
 use Exception;
 use Saloon\Enums\Timeout;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
 use Saloon\Contracts\Sender;
 use GuzzleHttp\RequestOptions;
@@ -169,7 +170,7 @@ class GuzzleSender implements Sender
         }
 
         if ($pendingRequest->query()->isNotEmpty()) {
-            $requestOptions[RequestOptions::QUERY] = $pendingRequest->query()->all();
+            $requestOptions[RequestOptions::QUERY] = Query::build($pendingRequest->query()->all());
         }
 
         foreach ($pendingRequest->config()->all() as $configVariable => $value) {


### PR DESCRIPTION
This is related to issue #240 

I am currently using Saloon with the Gmail API. There's a query param here called `labelIds[]`
https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list

Contrary to the parameter name in the doc, it must not have the brackets at the end of the param name in order to work. However, this is exactly what Guzzle does.

if I send the defaultQuery has:

```php
["labelIds" => ["INBOX", "UNREAD"]]
````

Then Guzzle will automatically create this query string on the request:
```
?labelIds[]=INBOX&labelIds[]=UNREAD
```

With the small change in this pull request, it renders to what Google expects, which is:
```
?labelIds=INBOX&labelIds=UNREAD
```

Although this might be a breaking change initially for some other API clients, if I'd like to still use the previous behaviour, I could just add the [] in my array key name.