### PR TITLE
Feature | Show request endpoint in MockClient exception message

### DIFF
--- a/src/Exceptions/NoMockResponseFoundException.php
+++ b/src/Exceptions/NoMockResponseFoundException.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Saloon\Exceptions;
 
+use Saloon\Contracts\Request;
+
 class NoMockResponseFoundException extends SaloonException
 {
-    public function __construct()
+    public function __construct(Request $request)
     {
-        parent::__construct('Saloon was unable to guess a mock response for your request, consider using a wildcard url mock or a connector mock.');
+        parent::__construct("Saloon was unable to guess a mock response for your request [{$request->resolveEndpoint()}], consider using a wildcard url mock or a connector mock.");
     }
 }

--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -159,7 +159,7 @@ class MockClient implements MockClientContract
         }
 
         if (empty($this->sequenceResponses)) {
-            throw new NoMockResponseFoundException;
+            throw new NoMockResponseFoundException($request);
         }
 
         return $this->mockResponseValue($this->getNextFromSequence(), $pendingRequest);


### PR DESCRIPTION
PR for my feature request in https://github.com/Sammyjo20/Saloon/discussions/219#discussioncomment-6616142 

Displays the missing endpoint in the exception for easier debugging tests.

How Laravel, `Http::preventStrayRequest()` does it:
![image](https://github.com/Sammyjo20/Saloon/assets/60270137/b0f9b0a4-0bef-431a-9e25-3ce4bef7a72e)

**This PR:**
![image](https://github.com/Sammyjo20/Saloon/assets/60270137/169f0400-73b8-4ab7-883b-dd4ce0c3cfcd)

**Before this PR:**
![image](https://github.com/Sammyjo20/Saloon/assets/60270137/d3548dda-5352-4e63-8ec0-dc3265ade6ca)
