### PR TITLE
Feature | V3 - Allow Middleware To Be Reordered

### DIFF
--- a/src/Contracts/MiddlewarePipeline.php
+++ b/src/Contracts/MiddlewarePipeline.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Saloon\Contracts;
 
+use Saloon\Data\PipeOrder;
+
 interface MiddlewarePipeline
 {
     /**
@@ -12,7 +14,7 @@ interface MiddlewarePipeline
      * @param callable(\Saloon\Contracts\PendingRequest): (\Saloon\Contracts\PendingRequest|\Saloon\Contracts\FakeResponse|void) $callable
      * @return $this
      */
-    public function onRequest(callable $callable, bool $prepend = false, ?string $name = null): static;
+    public function onRequest(callable $callable, ?string $name = null, ?PipeOrder $order = null): static;
 
     /**
      * Add a middleware after the request is sent
@@ -20,7 +22,7 @@ interface MiddlewarePipeline
      * @param callable(\Saloon\Contracts\Response): (\Saloon\Contracts\Response|void) $callable
      * @return $this
      */
-    public function onResponse(callable $callable, bool $prepend = false, ?string $name = null): static;
+    public function onResponse(callable $callable, ?string $name = null, ?PipeOrder $order = null): static;
 
     /**
      * Process the request pipeline.

--- a/src/Contracts/Pipeline.php
+++ b/src/Contracts/Pipeline.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Saloon\Contracts;
 
+use Saloon\Data\PipeOrder;
+
 interface Pipeline
 {
     /**
@@ -13,7 +15,7 @@ interface Pipeline
      * @return $this
      * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
-    public function pipe(callable $callable, bool $prepend = false, ?string $name = null): static;
+    public function pipe(callable $callable, ?string $name = null, ?PipeOrder $order = null): static;
 
     /**
      * Process the pipeline.

--- a/src/Data/Pipe.php
+++ b/src/Data/Pipe.php
@@ -18,6 +18,7 @@ class Pipe
     public function __construct(
         callable $callable,
         readonly public ?string $name = null,
+        readonly public ?PipeOrder $order = null,
     ) {
         $this->callable = $callable(...);
     }

--- a/src/Data/PipeOrder.php
+++ b/src/Data/PipeOrder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Saloon\Data;
+
+use Saloon\Enums\Order;
+
+class PipeOrder
+{
+    /**
+     * Constructor
+     *
+     * @param \Saloon\Enums\Order $type
+     */
+    public function __construct(
+        public readonly Order $type,
+    )
+    {
+        //
+    }
+
+    /**
+     * Run the middleware first
+     *
+     * @return self
+     */
+    public static function first(): self
+    {
+        return new self(Order::FIRST);
+    }
+
+    /**
+     * Run the middleware last
+     *
+     * @return self
+     */
+    public static function last(): self
+    {
+        return new self(Order::LAST);
+    }
+}

--- a/src/Data/PipeOrder.php
+++ b/src/Data/PipeOrder.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Saloon\Data;
 
 use Saloon\Enums\Order;
@@ -8,20 +10,15 @@ class PipeOrder
 {
     /**
      * Constructor
-     *
-     * @param \Saloon\Enums\Order $type
      */
     public function __construct(
         public readonly Order $type,
-    )
-    {
+    ) {
         //
     }
 
     /**
      * Run the middleware first
-     *
-     * @return self
      */
     public static function first(): self
     {
@@ -30,8 +27,6 @@ class PipeOrder
 
     /**
      * Run the middleware last
-     *
-     * @return self
      */
     public static function last(): self
     {

--- a/src/Enums/Order.php
+++ b/src/Enums/Order.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Saloon\Enums;
+
+enum Order: string
+{
+    case FIRST = 'first';
+    case LAST = 'last';
+}

--- a/src/Enums/Order.php
+++ b/src/Enums/Order.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Saloon\Enums;
 
 enum Order: string

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Saloon\Helpers;
 
 use Closure;
+use Saloon\Data\PipeOrder;
 use Saloon\Contracts\Response;
 use Saloon\Contracts\FakeResponse;
 use Saloon\Contracts\PendingRequest;
 use Saloon\Contracts\Pipeline as PipelineContract;
 use Saloon\Contracts\MiddlewarePipeline as MiddlewarePipelineContract;
-use Saloon\Data\PipeOrder;
 
 class MiddlewarePipeline implements MiddlewarePipelineContract
 {
@@ -52,7 +52,6 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
          * Do note that this is entirely about our *wrapping* Closure below.
          * The provided callable doesn't affect the MiddlewarePipeline.
          */
-
         $this->requestPipeline->pipe(static function (PendingRequest $pendingRequest) use ($callable): PendingRequest {
             $result = $callable($pendingRequest);
 
@@ -89,7 +88,6 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
          * Do note that this is entirely about our *wrapping* Closure below.
          * The provided callable doesn't affect the MiddlewarePipeline.
          */
-
         $this->responsePipeline->pipe(static function (Response $response) use ($callable): Response {
             $result = $callable($response);
 

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -10,6 +10,7 @@ use Saloon\Contracts\FakeResponse;
 use Saloon\Contracts\PendingRequest;
 use Saloon\Contracts\Pipeline as PipelineContract;
 use Saloon\Contracts\MiddlewarePipeline as MiddlewarePipelineContract;
+use Saloon\Data\PipeOrder;
 
 class MiddlewarePipeline implements MiddlewarePipelineContract
 {
@@ -39,7 +40,7 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
      * @return $this
      * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
-    public function onRequest(callable $callable, bool $prepend = false, ?string $name = null): static
+    public function onRequest(callable $callable, ?string $name = null, ?PipeOrder $order = null): static
     {
         /**
          * For some reason, PHP is not destructing non-static Closures, or 'things' using non-static Closures, correctly, keeping unused objects intact.
@@ -51,6 +52,7 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
          * Do note that this is entirely about our *wrapping* Closure below.
          * The provided callable doesn't affect the MiddlewarePipeline.
          */
+
         $this->requestPipeline->pipe(static function (PendingRequest $pendingRequest) use ($callable): PendingRequest {
             $result = $callable($pendingRequest);
 
@@ -63,7 +65,7 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
             }
 
             return $pendingRequest;
-        }, $prepend, $name);
+        }, $name, $order);
 
         return $this;
     }
@@ -75,7 +77,7 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
      * @return $this
      * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
-    public function onResponse(callable $callable, bool $prepend = false, ?string $name = null): static
+    public function onResponse(callable $callable, ?string $name = null, ?PipeOrder $order = null): static
     {
         /**
          * For some reason, PHP is not destructing non-static Closures, or 'things' using non-static Closures, correctly, keeping unused objects intact.
@@ -87,11 +89,12 @@ class MiddlewarePipeline implements MiddlewarePipelineContract
          * Do note that this is entirely about our *wrapping* Closure below.
          * The provided callable doesn't affect the MiddlewarePipeline.
          */
+
         $this->responsePipeline->pipe(static function (Response $response) use ($callable): Response {
             $result = $callable($response);
 
             return $result instanceof Response ? $result : $response;
-        }, $prepend, $name);
+        }, $name, $order);
 
         return $this;
     }

--- a/src/Helpers/Pipeline.php
+++ b/src/Helpers/Pipeline.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Saloon\Helpers;
 
 use Saloon\Data\Pipe;
-use Saloon\Data\PipeOrder;
 use Saloon\Enums\Order;
+use Saloon\Data\PipeOrder;
 use Saloon\Exceptions\DuplicatePipeNameException;
 use Saloon\Contracts\Pipeline as PipelineContract;
 
@@ -53,15 +53,13 @@ class Pipeline implements PipelineContract
 
     /**
      * Sort the pipes based on the "order" classes
-     *
-     * @return array
      */
     protected function sortPipes(): array
     {
         $pipes = $this->pipes;
 
         /** @var array<\Saloon\Data\PipeOrder> $pipeNames */
-        $pipeOrders = array_map(static fn(Pipe $pipe) => $pipe->order, $pipes);
+        $pipeOrders = array_map(static fn (Pipe $pipe) => $pipe->order, $pipes);
 
         // Now we'll iterate through the pipe orders and if a specific pipe
         // requests to be placed at the top - we will move the pipe to the

--- a/src/Http/Middleware/DetermineMockResponse.php
+++ b/src/Http/Middleware/DetermineMockResponse.php
@@ -14,7 +14,10 @@ class DetermineMockResponse implements RequestMiddleware
     /**
      * Guess a mock response
      *
+     * @param \Saloon\Contracts\PendingRequest $pendingRequest
+     * @return \Saloon\Contracts\PendingRequest|\Saloon\Http\Faking\MockResponse
      * @throws \JsonException
+     * @throws \Saloon\Exceptions\FixtureException
      * @throws \Saloon\Exceptions\FixtureMissingException
      */
     public function __invoke(PendingRequest $pendingRequest): PendingRequest|MockResponse

--- a/src/Http/Middleware/DetermineMockResponse.php
+++ b/src/Http/Middleware/DetermineMockResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Http\Middleware;
 
+use Saloon\Data\PipeOrder;
 use Saloon\Http\Faking\Fixture;
 use Saloon\Contracts\PendingRequest;
 use Saloon\Http\Faking\MockResponse;
@@ -52,7 +53,7 @@ class DetermineMockResponse implements RequestMiddleware
         // middleware on the response to record the response.
 
         if (is_null($mockResponse) && $mockObject instanceof Fixture) {
-            $pendingRequest->middleware()->onResponse(new RecordFixture($mockObject), true, 'recordFixture');
+            $pendingRequest->middleware()->onResponse(new RecordFixture($mockObject),'recordFixture', PipeOrder::first());
         }
 
         return $pendingRequest;

--- a/src/Http/Middleware/DetermineMockResponse.php
+++ b/src/Http/Middleware/DetermineMockResponse.php
@@ -15,8 +15,6 @@ class DetermineMockResponse implements RequestMiddleware
     /**
      * Guess a mock response
      *
-     * @param \Saloon\Contracts\PendingRequest $pendingRequest
-     * @return \Saloon\Contracts\PendingRequest|\Saloon\Http\Faking\MockResponse
      * @throws \JsonException
      * @throws \Saloon\Exceptions\FixtureException
      * @throws \Saloon\Exceptions\FixtureMissingException
@@ -53,7 +51,7 @@ class DetermineMockResponse implements RequestMiddleware
         // middleware on the response to record the response.
 
         if (is_null($mockResponse) && $mockObject instanceof Fixture) {
-            $pendingRequest->middleware()->onResponse(new RecordFixture($mockObject),'recordFixture', PipeOrder::first());
+            $pendingRequest->middleware()->onResponse(new RecordFixture($mockObject), 'recordFixture', PipeOrder::first());
         }
 
         return $pendingRequest;

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -156,11 +156,11 @@ class PendingRequest implements PendingRequestContract
         // body, delay and also running authenticators on the request.
 
         $middleware
-            ->onRequest(new MergeRequestProperties, false, 'mergeRequestProperties')
-            ->onRequest(new MergeBody, false, 'mergeBody')
-            ->onRequest(new MergeDelay, false, 'mergeDelay')
-            ->onRequest(new AuthenticateRequest, false, 'authenticateRequest')
-            ->onRequest(new DetermineMockResponse, false, 'determineMockResponse');
+            ->onRequest(new MergeRequestProperties, 'mergeRequestProperties')
+            ->onRequest(new MergeBody, 'mergeBody')
+            ->onRequest(new MergeDelay, 'mergeDelay')
+            ->onRequest(new AuthenticateRequest, 'authenticateRequest')
+            ->onRequest(new DetermineMockResponse, 'determineMockResponse');
 
         // Next, we'll merge in our "Global" middleware which can be middleware set by the
         // user or set by Saloon's plugins like the Laravel Plugin. It's best that this
@@ -186,15 +186,15 @@ class PendingRequest implements PendingRequestContract
         // Next, we'll delay the request if we need to. This will run before the final
         // middleware.
 
-        $middleware->onRequest(new DelayMiddleware, false, 'delayMiddleware');
+        $middleware->onRequest(new DelayMiddleware, 'delayMiddleware');
 
         // Finally, we'll apply our "final" middleware. This is a group of middleware
         // that will run at the end, no matter what. This is useful for debugging and
         // events where we can guarantee that the middleware will be run at the end.
 
         $middleware
-            ->onRequest(new DebugRequest, false, 'debugRequest')
-            ->onResponse(new DebugResponse, false, 'debugResponse');
+            ->onRequest(new DebugRequest, 'debugRequest')
+            ->onResponse(new DebugResponse, 'debugResponse');
 
         // Next, we will execute the request middleware pipeline which will
         // process the middleware in the order we added it.

--- a/tests/Unit/MiddlewarePipelineTest.php
+++ b/tests/Unit/MiddlewarePipelineTest.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use Saloon\Data\Pipe;
-use Saloon\Data\PipeOrder;
 use Saloon\Http\Response;
+use Saloon\Data\PipeOrder;
 use Saloon\Http\PendingRequest;
 use GuzzleHttp\Psr7\HttpFactory;
 use Saloon\Http\Faking\MockClient;


### PR DESCRIPTION
This PR removes the "prepend" method on the middleware and replaces it with a new argument "order". This accepts a `PipeOrder` class where you can define if a middleware should run at the beginning or at the end of the middleware pipeline. If multiple middleware request to run at the start/end it will be in order or who requested first.

This allows us to have middleware that always runs at the end of a request lifecycle for things like debugging and at the beginning of the response lifecycle for events/debugging and to run before the "AlwaysThrowOnErrors" trait.

This PR also changes the middleware order.