### PR TITLE
Feature | V2 Prevent Stray Requests

### DIFF
--- a/src/Exceptions/StrayRequestException.php
+++ b/src/Exceptions/StrayRequestException.php
@@ -8,6 +8,6 @@ class StrayRequestException extends SaloonException
 {
     public function __construct()
     {
-        parent::__construct('Attempted to make a real API request! Make sure to use a MockClient or Saloon::fake() if you are using Laravel.');
+        parent::__construct('Attempted to make a real API request! Make sure to use a mock response or fixture.');
     }
 }

--- a/src/Exceptions/StrayRequestException.php
+++ b/src/Exceptions/StrayRequestException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Saloon\Exceptions;
 
 class StrayRequestException extends SaloonException

--- a/src/Exceptions/StrayRequestException.php
+++ b/src/Exceptions/StrayRequestException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Saloon\Exceptions;
+
+class StrayRequestException extends SaloonException
+{
+    public function __construct()
+    {
+        parent::__construct('Attempted to make a real API request! Make sure to use a MockClient or Saloon::fake() if you are using Laravel.');
+    }
+}

--- a/src/Helpers/Config.php
+++ b/src/Helpers/Config.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Saloon\Helpers;
 
+use Saloon\Contracts\PendingRequest;
 use Saloon\Contracts\Sender;
+use Saloon\Exceptions\SaloonException;
+use Saloon\Exceptions\StrayRequestException;
 use Saloon\Http\Senders\GuzzleSender;
 use Saloon\Contracts\MiddlewarePipeline as MiddlewarePipelineContract;
 
@@ -100,5 +103,19 @@ final class Config
     public static function resetDefaultSender(): void
     {
         self::$defaultSender = self::DEFAULT_SENDER;
+    }
+
+    /**
+     * Throw an exception if a request without a MockClient is made.
+     *
+     * @return void
+     */
+    public static function preventStrayRequests(): void
+    {
+        self::middleware()->onRequest(static function (PendingRequest $pendingRequest) {
+            if (! $pendingRequest->hasMockClient()) {
+                throw new StrayRequestException;
+            }
+        });
     }
 }

--- a/src/Helpers/Config.php
+++ b/src/Helpers/Config.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Saloon\Helpers;
 
-use Saloon\Contracts\PendingRequest;
 use Saloon\Contracts\Sender;
-use Saloon\Exceptions\SaloonException;
-use Saloon\Exceptions\StrayRequestException;
+use Saloon\Contracts\PendingRequest;
 use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Exceptions\StrayRequestException;
 use Saloon\Contracts\MiddlewarePipeline as MiddlewarePipelineContract;
 
 final class Config

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Saloon\Exceptions\SaloonException;
+use Saloon\Exceptions\StrayRequestException;
 use Saloon\Http\Response;
 use Saloon\Helpers\Config;
 use Saloon\Http\PendingRequest;
@@ -67,4 +69,15 @@ test('you can change how the global default sender is resolved', function () {
     $sender = TestConnector::make()->sender();
 
     expect($sender)->toBeInstanceOf(GuzzleSender::class);
+});
+
+test('you can prevent stray api requests', function () {
+    Config::preventStrayRequests();
+
+    $this->expectException(StrayRequestException::class);
+    $this->expectExceptionMessage('Attempted to make a real API request! Make sure to use a MockClient or Saloon::fake() if you are using Laravel.');
+
+    TestConnector::make()->send(new UserRequest);
+
+    Config::resetMiddleware();
 });

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -2,14 +2,13 @@
 
 declare(strict_types=1);
 
-use Saloon\Exceptions\SaloonException;
-use Saloon\Exceptions\StrayRequestException;
 use Saloon\Http\Response;
 use Saloon\Helpers\Config;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Exceptions\StrayRequestException;
 use Saloon\Tests\Fixtures\Senders\ArraySender;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -74,7 +74,7 @@ test('you can prevent stray api requests', function () {
     Config::preventStrayRequests();
 
     $this->expectException(StrayRequestException::class);
-    $this->expectExceptionMessage('Attempted to make a real API request! Make sure to use a MockClient or Saloon::fake() if you are using Laravel.');
+    $this->expectExceptionMessage('Attempted to make a real API request! Make sure to use a mock response or fixture.');
 
     TestConnector::make()->send(new UserRequest);
 


### PR DESCRIPTION
This PR introduces a new option you can use in your tests to prevent real API calls from happening in your tests. 

```php
Config::preventStrayRequests();
```