### PR TITLE
Fix | V3 - Improve middleware order and add support for PHP 8.3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
         stability: [ prefer-lowest, prefer-stable ]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "homepage": "https://github.com/saloonphp/saloon",
     "require": {
         "php": "^8.1",
-        "guzzlehttp/guzzle": "^7.7",
+        "guzzlehttp/guzzle": "^7.6",
         "guzzlehttp/promises": "^1.5 || ^2.0",
         "guzzlehttp/psr7": "^2.0",
         "psr/http-factory": "^1.0",

--- a/src/Http/Middleware/ValidateProperties.php
+++ b/src/Http/Middleware/ValidateProperties.php
@@ -21,7 +21,7 @@ class ValidateProperties implements RequestMiddleware
 
         foreach ($pendingRequest->headers()->all() as $key => $unused) {
             if (! is_string($key)) {
-                throw new InvalidHeaderException('One or more of the headers are invalid. Make sure to use the header name as the key. For example: \'Content-Type\' => \'application/json\'.');
+                throw new InvalidHeaderException('One or more of the headers are invalid. Make sure to use the header name as the key. For example: [\'Content-Type\' => \'application/json\'].');
             }
         }
     }

--- a/src/Http/PendingRequest/AuthenticatePendingRequest.php
+++ b/src/Http/PendingRequest/AuthenticatePendingRequest.php
@@ -2,23 +2,24 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\Authenticator;
-use Saloon\Contracts\RequestMiddleware;
 
-class AuthenticateRequest implements RequestMiddleware
+class AuthenticatePendingRequest
 {
     /**
      * Authenticate the pending request
      */
-    public function __invoke(PendingRequest $pendingRequest): void
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         $authenticator = $pendingRequest->getAuthenticator();
 
         if ($authenticator instanceof Authenticator) {
             $authenticator->set($pendingRequest);
         }
+
+        return $pendingRequest;
     }
 }

--- a/src/Http/PendingRequest/BootConnectorAndRequest.php
+++ b/src/Http/PendingRequest/BootConnectorAndRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Http\PendingRequest;
+
+use Saloon\Http\PendingRequest;
+
+class BootConnectorAndRequest
+{
+    /**
+     * Boot the connector and request
+     */
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
+    {
+        $pendingRequest->getConnector()->boot($pendingRequest);
+        $pendingRequest->getRequest()->boot($pendingRequest);
+
+        return $pendingRequest;
+    }
+}

--- a/src/Http/PendingRequest/BootPlugins.php
+++ b/src/Http/PendingRequest/BootPlugins.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Http\PendingRequest;
+
+use Saloon\Helpers\Helpers;
+use Saloon\Http\PendingRequest;
+
+class BootPlugins
+{
+    /**
+     * Boot the plugins
+     */
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
+    {
+        $connector = $pendingRequest->getConnector();
+        $request = $pendingRequest->getRequest();
+
+        $connectorTraits = Helpers::classUsesRecursive($connector);
+        $requestTraits = Helpers::classUsesRecursive($request);
+
+        foreach ($connectorTraits as $connectorTrait) {
+            Helpers::bootPlugin($pendingRequest, $connector, $connectorTrait);
+        }
+
+        foreach ($requestTraits as $requestTrait) {
+            Helpers::bootPlugin($pendingRequest, $request, $requestTrait);
+        }
+
+        return $pendingRequest;
+    }
+}

--- a/src/Http/PendingRequest/DetermineMockResponse.php
+++ b/src/Http/PendingRequest/DetermineMockResponse.php
@@ -2,24 +2,26 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Enums\PipeOrder;
 use Saloon\Http\Faking\Fixture;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockResponse;
-use Saloon\Contracts\RequestMiddleware;
+use Saloon\Http\Middleware\RecordFixture;
 
-class DetermineMockResponse implements RequestMiddleware
+class DetermineMockResponse
 {
     /**
      * Guess a mock response
      *
      * @throws \JsonException
+     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      * @throws \Saloon\Exceptions\FixtureException
      * @throws \Saloon\Exceptions\FixtureMissingException
+     * @throws \Saloon\Exceptions\NoMockResponseFoundException
      */
-    public function __invoke(PendingRequest $pendingRequest): PendingRequest|MockResponse
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         if ($pendingRequest->hasMockClient() === false) {
             return $pendingRequest;
@@ -40,10 +42,10 @@ class DetermineMockResponse implements RequestMiddleware
 
         // If the mock response is a valid instance, we will return it.
         // The middleware pipeline will recognise this and will set
-        // it as the "FakeResponse" on the request.
+        // it as the "FakeResponse" on the PendingRequest.
 
         if ($mockResponse instanceof MockResponse) {
-            return $mockResponse;
+            return $pendingRequest->setFakeResponse($mockResponse);
         }
 
         // However if the mock response is not valid because it is

--- a/src/Http/PendingRequest/MergeBody.php
+++ b/src/Http/PendingRequest/MergeBody.php
@@ -13,7 +13,7 @@ use Saloon\Repositories\Body\MultipartBodyRepository;
 class MergeBody
 {
     /**
-     * Register a request middleware
+     * Merge connector and request body
      *
      * @throws \Saloon\Exceptions\PendingRequestException
      */

--- a/src/Http/PendingRequest/MergeBody.php
+++ b/src/Http/PendingRequest/MergeBody.php
@@ -2,23 +2,22 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\Body\HasBody;
-use Saloon\Contracts\RequestMiddleware;
 use Saloon\Contracts\Body\MergeableBody;
 use Saloon\Exceptions\PendingRequestException;
 use Saloon\Repositories\Body\MultipartBodyRepository;
 
-class MergeBody implements RequestMiddleware
+class MergeBody
 {
     /**
      * Register a request middleware
      *
      * @throws \Saloon\Exceptions\PendingRequestException
      */
-    public function __invoke(PendingRequest $pendingRequest): void
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         $connector = $pendingRequest->getConnector();
         $request = $pendingRequest->getRequest();
@@ -27,7 +26,7 @@ class MergeBody implements RequestMiddleware
         $requestBody = $request instanceof HasBody ? $request->body() : null;
 
         if (is_null($connectorBody) && is_null($requestBody)) {
-            return;
+            return $pendingRequest;
         }
 
         // When both the connector and the request use the `HasBody` interface - we will enforce
@@ -64,5 +63,7 @@ class MergeBody implements RequestMiddleware
         }
 
         $pendingRequest->setBody($body);
+
+        return $pendingRequest;
     }
 }

--- a/src/Http/PendingRequest/MergeDelay.php
+++ b/src/Http/PendingRequest/MergeDelay.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Http\PendingRequest;
-use Saloon\Contracts\RequestMiddleware;
 
-class MergeDelay implements RequestMiddleware
+class MergeDelay
 {
     /**
      * Register a request middleware
      */
-    public function __invoke(PendingRequest $pendingRequest): void
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         $connector = $pendingRequest->getConnector();
         $request = $pendingRequest->getRequest();
@@ -22,5 +21,7 @@ class MergeDelay implements RequestMiddleware
         if ($request->delay()->isNotEmpty()) {
             $pendingRequest->delay()->set($request->delay()->get());
         }
+
+        return $pendingRequest;
     }
 }

--- a/src/Http/PendingRequest/MergeDelay.php
+++ b/src/Http/PendingRequest/MergeDelay.php
@@ -9,7 +9,7 @@ use Saloon\Http\PendingRequest;
 class MergeDelay
 {
     /**
-     * Register a request middleware
+     * Merge connector and request delay
      */
     public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {

--- a/src/Http/PendingRequest/MergeRequestProperties.php
+++ b/src/Http/PendingRequest/MergeRequestProperties.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Http\PendingRequest;
-use Saloon\Contracts\RequestMiddleware;
 
-class MergeRequestProperties implements RequestMiddleware
+class MergeRequestProperties
 {
     /**
      * Register a request middleware
      */
-    public function __invoke(PendingRequest $pendingRequest): void
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         $connector = $pendingRequest->getConnector();
         $request = $pendingRequest->getRequest();
@@ -31,5 +30,11 @@ class MergeRequestProperties implements RequestMiddleware
             $connector->config()->all(),
             $request->config()->all()
         );
+
+        $pendingRequest->middleware()
+            ->merge($connector->middleware())
+            ->merge($request->middleware());
+
+        return $pendingRequest;
     }
 }

--- a/src/Http/PendingRequest/MergeRequestProperties.php
+++ b/src/Http/PendingRequest/MergeRequestProperties.php
@@ -9,7 +9,7 @@ use Saloon\Http\PendingRequest;
 class MergeRequestProperties
 {
     /**
-     * Register a request middleware
+     * Merge connector and request properties (headers, query, config, middleware)
      */
     public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {

--- a/tests/Unit/PendingRequestTest.php
+++ b/tests/Unit/PendingRequestTest.php
@@ -49,7 +49,7 @@ test('the pending request validates properly formed headers', function () {
     ]);
 
     $this->expectException(InvalidHeaderException::class);
-    $this->expectExceptionMessage('One or more of the headers are invalid. Make sure to use the header name as the key. For example: \'Content-Type\' => \'application/json\'.');
+    $this->expectExceptionMessage('One or more of the headers are invalid. Make sure to use the header name as the key. For example: [\'Content-Type\' => \'application/json\'].');
 
     connector()->createPendingRequest($request);
 });


### PR DESCRIPTION
This PR introduces some final changes to how the `PendingRequest` is constructed. While working on v3, I attempted to migrate every action in the`PendingRequest` into a middleware. When working on my Saloon plugins like the cache plugin, I realised that by running everything in middleware, there was a chance that middleware could be registered before things like headers, config and other middleware were merged into the `PendingRequest` - and things I wouldn't want to be overwritten could be changed. 

I have mulled over and revised this order many times, but I have finally managed to crack it.

When you send a request a, `PendingRequest` class is created which is used as an intermediary class between your connector and requests. It's a place where everything can be merged into one class and everything can be standardized. The order in which things are merged is optimized for the best developer experience. 

## The New Middleware / Execution Order
The new order of execution is as follows:

1. Register Global Middleware
2. Register Mock Middleware
3. Boot Plugins
4. Merge Request Properties
5. Merge Body
6. Merge Delay
7. Run authenticators (and make any future ones run instantly)
8. Boot Connector / Request
9. Delay Middleware
10. Run Middleware Pipeline

When the middleware pipeline is executed, the middleware will be executed in the following order:

1. Global Middleware
2. Mock Middleware
3. Plugin Middleware
4. User Middleware
5. Boot Middleware
6. Delay Middleware

## Changes from v2

### Global middleware and mock middleware is now executed first
Previously, the global middleware and mock middleware would run after the user's middleware, potentially overwriting anything the user has set. This was initially written because I assumed the user may want to "set" the mock client inside of middleware. Now that I realise that's not really a use case I have moved it to run first. This has a couple of benefits:

- The mock response is determined straight away, so all future middleware can see the "fake response" that is going to be sent. This is great for debugging.
- The fake response can be easily swapped out with something different by using `$pendingRequest->setFakeResponse()` which gives the user better control.

### Authenticators are now executed before middleware starts
Previously, you wouldn't be able to see the result of `$request->withTokenAuth()` or `$request->authenticate()` until you `dd()`ed the PendingRequest's headers. This isn't very developer friendly as it made it appear that the headers were never being set. Now, we will apply the authenticators before middleware is authenticated. This means that inside of middleware, you will be able to see any authentication tokens applied and also choose to overwrite them if needed. This is also much better for debugging.

## Reviewing

I recommend opening the `PendingRequest` file and reading through it - please let me know if there's anything in here which could be improved for better readability/performance.

https://github.com/saloonphp/saloon/blob/942d9740cf8ae626d6def7e8919170f4b6e86244/src/Http/PendingRequest.php