### PR TITLE
Feature | V3 - Add `all` method back onto body

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        php: [ 8.1, 8.2 ]
+        php: [ 8.1, 8.2, 8.3 ]
         stability: [ prefer-lowest, prefer-stable ]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "homepage": "https://github.com/saloonphp/saloon",
     "require": {
         "php": "^8.1",
-        "guzzlehttp/guzzle": "^7.7",
+        "guzzlehttp/guzzle": "^7.6",
         "guzzlehttp/promises": "^1.5 || ^2.0",
         "guzzlehttp/psr7": "^2.0",
         "psr/http-factory": "^1.0",

--- a/src/Contracts/Body/BodyRepository.php
+++ b/src/Contracts/Body/BodyRepository.php
@@ -17,16 +17,9 @@ interface BodyRepository
     public function set(mixed $value): static;
 
     /**
-     * Retrieve the raw data in the repository.
+     * Get the raw data in the repository.
      */
     public function all(): mixed;
-
-    /**
-     * Retrieve the raw data in the repository
-     *
-     * Alias of `all()`.
-     */
-    public function get(): mixed;
 
     /**
      * Determine if the repository is empty

--- a/src/Helpers/FixtureHelper.php
+++ b/src/Helpers/FixtureHelper.php
@@ -7,7 +7,7 @@ namespace Saloon\Helpers;
 /**
  * @internal
  */
-final class FixtureHelper
+class FixtureHelper
 {
     /**
      * Recursively replaces array attributes

--- a/src/Helpers/URLHelper.php
+++ b/src/Helpers/URLHelper.php
@@ -7,7 +7,7 @@ namespace Saloon\Helpers;
 /**
  * @internal
  */
-final class URLHelper
+class URLHelper
 {
     /**
      * Check if a URL matches a given pattern

--- a/src/Http/Middleware/ValidateProperties.php
+++ b/src/Http/Middleware/ValidateProperties.php
@@ -21,7 +21,7 @@ class ValidateProperties implements RequestMiddleware
 
         foreach ($pendingRequest->headers()->all() as $key => $unused) {
             if (! is_string($key)) {
-                throw new InvalidHeaderException('One or more of the headers are invalid. Make sure to use the header name as the key. For example: \'Content-Type\' => \'application/json\'.');
+                throw new InvalidHeaderException('One or more of the headers are invalid. Make sure to use the header name as the key. For example: [\'Content-Type\' => \'application/json\'].');
             }
         }
     }

--- a/src/Http/PendingRequest/AuthenticatePendingRequest.php
+++ b/src/Http/PendingRequest/AuthenticatePendingRequest.php
@@ -2,23 +2,24 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\Authenticator;
-use Saloon\Contracts\RequestMiddleware;
 
-class AuthenticateRequest implements RequestMiddleware
+class AuthenticatePendingRequest
 {
     /**
      * Authenticate the pending request
      */
-    public function __invoke(PendingRequest $pendingRequest): void
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         $authenticator = $pendingRequest->getAuthenticator();
 
         if ($authenticator instanceof Authenticator) {
             $authenticator->set($pendingRequest);
         }
+
+        return $pendingRequest;
     }
 }

--- a/src/Http/PendingRequest/BootConnectorAndRequest.php
+++ b/src/Http/PendingRequest/BootConnectorAndRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Http\PendingRequest;
+
+use Saloon\Http\PendingRequest;
+
+class BootConnectorAndRequest
+{
+    /**
+     * Boot the connector and request
+     */
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
+    {
+        $pendingRequest->getConnector()->boot($pendingRequest);
+        $pendingRequest->getRequest()->boot($pendingRequest);
+
+        return $pendingRequest;
+    }
+}

--- a/src/Http/PendingRequest/BootPlugins.php
+++ b/src/Http/PendingRequest/BootPlugins.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Http\PendingRequest;
+
+use Saloon\Helpers\Helpers;
+use Saloon\Http\PendingRequest;
+
+class BootPlugins
+{
+    /**
+     * Boot the plugins
+     */
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
+    {
+        $connector = $pendingRequest->getConnector();
+        $request = $pendingRequest->getRequest();
+
+        $connectorTraits = Helpers::classUsesRecursive($connector);
+        $requestTraits = Helpers::classUsesRecursive($request);
+
+        foreach ($connectorTraits as $connectorTrait) {
+            Helpers::bootPlugin($pendingRequest, $connector, $connectorTrait);
+        }
+
+        foreach ($requestTraits as $requestTrait) {
+            Helpers::bootPlugin($pendingRequest, $request, $requestTrait);
+        }
+
+        return $pendingRequest;
+    }
+}

--- a/src/Http/PendingRequest/DetermineMockResponse.php
+++ b/src/Http/PendingRequest/DetermineMockResponse.php
@@ -2,24 +2,26 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Enums\PipeOrder;
 use Saloon\Http\Faking\Fixture;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockResponse;
-use Saloon\Contracts\RequestMiddleware;
+use Saloon\Http\Middleware\RecordFixture;
 
-class DetermineMockResponse implements RequestMiddleware
+class DetermineMockResponse
 {
     /**
      * Guess a mock response
      *
      * @throws \JsonException
+     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      * @throws \Saloon\Exceptions\FixtureException
      * @throws \Saloon\Exceptions\FixtureMissingException
+     * @throws \Saloon\Exceptions\NoMockResponseFoundException
      */
-    public function __invoke(PendingRequest $pendingRequest): PendingRequest|MockResponse
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         if ($pendingRequest->hasMockClient() === false) {
             return $pendingRequest;
@@ -40,10 +42,10 @@ class DetermineMockResponse implements RequestMiddleware
 
         // If the mock response is a valid instance, we will return it.
         // The middleware pipeline will recognise this and will set
-        // it as the "FakeResponse" on the request.
+        // it as the "FakeResponse" on the PendingRequest.
 
         if ($mockResponse instanceof MockResponse) {
-            return $mockResponse;
+            return $pendingRequest->setFakeResponse($mockResponse);
         }
 
         // However if the mock response is not valid because it is

--- a/src/Http/PendingRequest/MergeBody.php
+++ b/src/Http/PendingRequest/MergeBody.php
@@ -13,7 +13,7 @@ use Saloon\Repositories\Body\MultipartBodyRepository;
 class MergeBody
 {
     /**
-     * Register a request middleware
+     * Merge connector and request body
      *
      * @throws \Saloon\Exceptions\PendingRequestException
      */

--- a/src/Http/PendingRequest/MergeBody.php
+++ b/src/Http/PendingRequest/MergeBody.php
@@ -51,7 +51,7 @@ class MergeBody
             // We'll clone the request body into the connector body so any properties on the request
             // body will take priority if they are using a keyed array.
 
-            $body = $repository->merge($requestBody->get());
+            $body = $repository->merge($requestBody->all());
         }
 
         // Now we'll check if the body is a MultipartBodyRepository. If it is, then we must

--- a/src/Http/PendingRequest/MergeBody.php
+++ b/src/Http/PendingRequest/MergeBody.php
@@ -2,23 +2,22 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\Body\HasBody;
-use Saloon\Contracts\RequestMiddleware;
 use Saloon\Contracts\Body\MergeableBody;
 use Saloon\Exceptions\PendingRequestException;
 use Saloon\Repositories\Body\MultipartBodyRepository;
 
-class MergeBody implements RequestMiddleware
+class MergeBody
 {
     /**
      * Register a request middleware
      *
      * @throws \Saloon\Exceptions\PendingRequestException
      */
-    public function __invoke(PendingRequest $pendingRequest): void
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         $connector = $pendingRequest->getConnector();
         $request = $pendingRequest->getRequest();
@@ -27,7 +26,7 @@ class MergeBody implements RequestMiddleware
         $requestBody = $request instanceof HasBody ? $request->body() : null;
 
         if (is_null($connectorBody) && is_null($requestBody)) {
-            return;
+            return $pendingRequest;
         }
 
         // When both the connector and the request use the `HasBody` interface - we will enforce
@@ -64,5 +63,7 @@ class MergeBody implements RequestMiddleware
         }
 
         $pendingRequest->setBody($body);
+
+        return $pendingRequest;
     }
 }

--- a/src/Http/PendingRequest/MergeDelay.php
+++ b/src/Http/PendingRequest/MergeDelay.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Http\PendingRequest;
-use Saloon\Contracts\RequestMiddleware;
 
-class MergeDelay implements RequestMiddleware
+class MergeDelay
 {
     /**
      * Register a request middleware
      */
-    public function __invoke(PendingRequest $pendingRequest): void
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         $connector = $pendingRequest->getConnector();
         $request = $pendingRequest->getRequest();
@@ -22,5 +21,7 @@ class MergeDelay implements RequestMiddleware
         if ($request->delay()->isNotEmpty()) {
             $pendingRequest->delay()->set($request->delay()->get());
         }
+
+        return $pendingRequest;
     }
 }

--- a/src/Http/PendingRequest/MergeDelay.php
+++ b/src/Http/PendingRequest/MergeDelay.php
@@ -9,7 +9,7 @@ use Saloon\Http\PendingRequest;
 class MergeDelay
 {
     /**
-     * Register a request middleware
+     * Merge connector and request delay
      */
     public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {

--- a/src/Http/PendingRequest/MergeRequestProperties.php
+++ b/src/Http/PendingRequest/MergeRequestProperties.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Saloon\Http\Middleware;
+namespace Saloon\Http\PendingRequest;
 
 use Saloon\Http\PendingRequest;
-use Saloon\Contracts\RequestMiddleware;
 
-class MergeRequestProperties implements RequestMiddleware
+class MergeRequestProperties
 {
     /**
      * Register a request middleware
      */
-    public function __invoke(PendingRequest $pendingRequest): void
+    public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {
         $connector = $pendingRequest->getConnector();
         $request = $pendingRequest->getRequest();
@@ -31,5 +30,11 @@ class MergeRequestProperties implements RequestMiddleware
             $connector->config()->all(),
             $request->config()->all()
         );
+
+        $pendingRequest->middleware()
+            ->merge($connector->middleware())
+            ->merge($request->middleware());
+
+        return $pendingRequest;
     }
 }

--- a/src/Http/PendingRequest/MergeRequestProperties.php
+++ b/src/Http/PendingRequest/MergeRequestProperties.php
@@ -9,7 +9,7 @@ use Saloon\Http\PendingRequest;
 class MergeRequestProperties
 {
     /**
-     * Register a request middleware
+     * Merge connector and request properties (headers, query, config, middleware)
      */
     public function __invoke(PendingRequest $pendingRequest): PendingRequest
     {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -109,8 +109,6 @@ class Response
 
     /**
      * Get the original request that created the response.
-     *
-     * @deprecated Will be removed in Saloon v4. Use $response->getPendingRequest()->getRequest() instead.
      */
     public function getRequest(): Request
     {

--- a/src/Repositories/Body/ArrayBodyRepository.php
+++ b/src/Repositories/Body/ArrayBodyRepository.php
@@ -79,18 +79,13 @@ class ArrayBodyRepository implements BodyRepository, MergeableBody
     }
 
     /**
-     * Get a specific key of the array
+     * Get the raw data in the repository.
      *
-     * @param array-key|null $key
-     * @return ($key is null ? array<array-key, mixed> : mixed)
+     * @return array<mixed, mixed>
      */
-    public function all(string|int|null $key = null, mixed $default = null): mixed
+    public function all(): array
     {
-        if (is_null($key)) {
-            return $this->data;
-        }
-
-        return $this->data[$key] ?? $default;
+        return $this->data;
     }
 
     /**
@@ -103,7 +98,11 @@ class ArrayBodyRepository implements BodyRepository, MergeableBody
      */
     public function get(string|int|null $key = null, mixed $default = null): mixed
     {
-        return $this->all($key, $default);
+        if (is_null($key)) {
+            return $this->all();
+        }
+
+        return $this->all()[$key] ?? $default;
     }
 
     /**

--- a/src/Repositories/Body/FormBodyRepository.php
+++ b/src/Repositories/Body/FormBodyRepository.php
@@ -16,6 +16,6 @@ class FormBodyRepository extends ArrayBodyRepository implements Stringable
      */
     public function __toString(): string
     {
-        return http_build_query($this->get());
+        return http_build_query($this->all());
     }
 }

--- a/src/Repositories/Body/JsonBodyRepository.php
+++ b/src/Repositories/Body/JsonBodyRepository.php
@@ -45,7 +45,7 @@ class JsonBodyRepository extends ArrayBodyRepository implements Stringable
      */
     public function __toString(): string
     {
-        $json = json_encode($this->get(), $this->getJsonFlags());
+        $json = json_encode($this->all(), $this->getJsonFlags());
 
         return $json === false ? '' : $json;
     }

--- a/src/Repositories/Body/MultipartBodyRepository.php
+++ b/src/Repositories/Body/MultipartBodyRepository.php
@@ -111,29 +111,23 @@ class MultipartBodyRepository implements BodyRepository, MergeableBody
     }
 
     /**
-     * Get a specific key of the array
+     * Get the raw data in the repository.
      *
-     * @return ($key is null ? array<array-key, mixed> : mixed)
+     * @return array<\Saloon\Data\MultipartValue>
      */
-    public function all(string|int $key = null, mixed $default = null): mixed
+    public function all(): array
     {
-        if (is_null($key)) {
-            return $this->data->get();
-        }
-
-        return $this->data->get($key, $default);
+        return $this->data->all();
     }
 
     /**
      * Get a specific key of the array
      *
-     * Alias of `all()`.
-     *
-     * @return ($key is null ? array<array-key, mixed> : mixed)
+     * @param array-key $key
      */
-    public function get(string|int $key = null, mixed $default = null): mixed
+    public function get(string|int $key, mixed $default = null): MultipartValue
     {
-        return $this->all($key, $default);
+        return $this->data->get($key, $default);
     }
 
     /**
@@ -210,6 +204,6 @@ class MultipartBodyRepository implements BodyRepository, MergeableBody
             throw new BodyException('Unable to create a multipart body stream because the multipart body factory was not set.');
         }
 
-        return $this->multipartBodyFactory->create($streamFactory, (array)$this->get(), $this->getBoundary());
+        return $this->multipartBodyFactory->create($streamFactory, $this->all(), $this->getBoundary());
     }
 }

--- a/src/Repositories/Body/StreamBodyRepository.php
+++ b/src/Repositories/Body/StreamBodyRepository.php
@@ -50,8 +50,6 @@ class StreamBodyRepository implements BodyRepository
 
     /**
      * Retrieve the stream from the repository
-     *
-     * @return StreamInterface|resource|null
      */
     public function all(): mixed
     {
@@ -61,9 +59,7 @@ class StreamBodyRepository implements BodyRepository
     /**
      * Retrieve the stream from the repository
      *
-     * Alias of `all()`.
-     *
-     * @return StreamInterface|resource|null
+     * Alias of "all" method.
      */
     public function get(): mixed
     {

--- a/src/Repositories/Body/StringBodyRepository.php
+++ b/src/Repositories/Body/StringBodyRepository.php
@@ -49,16 +49,6 @@ class StringBodyRepository implements BodyRepository, Stringable
     }
 
     /**
-     * Retrieve all in the repository
-     *
-     * Alias of `all()`.
-     */
-    public function get(): ?string
-    {
-        return $this->all();
-    }
-
-    /**
      * Determine if the repository is empty
      */
     public function isEmpty(): bool
@@ -79,6 +69,6 @@ class StringBodyRepository implements BodyRepository, Stringable
      */
     public function __toString(): string
     {
-        return $this->get() ?? '';
+        return $this->all() ?? '';
     }
 }

--- a/tests/Feature/Body/HasFormBodyTest.php
+++ b/tests/Feature/Body/HasFormBodyTest.php
@@ -13,7 +13,7 @@ use Saloon\Tests\Fixtures\Requests\HasFormBodyRequest;
 test('the default body is loaded with the content type header', function () {
     $request = new HasFormBodyRequest();
 
-    expect($request->body()->get())->toEqual([
+    expect($request->body()->all())->toEqual([
         'name' => 'Sam',
         'catchphrase' => 'Yeehaw!',
     ]);

--- a/tests/Feature/Body/HasJsonBodyTest.php
+++ b/tests/Feature/Body/HasJsonBodyTest.php
@@ -17,7 +17,7 @@ use Saloon\Tests\Fixtures\Requests\HasMultipartBodyRequest;
 test('the default body is loaded with the content type header', function () {
     $request = new HasJsonBodyRequest();
 
-    expect($request->body()->get())->toEqual([
+    expect($request->body()->all())->toEqual([
         'name' => 'Sam',
         'catchphrase' => 'Yeehaw!',
     ]);
@@ -43,12 +43,12 @@ test('when both the connector and the request have the same request bodies they 
     $connector = new HasJsonBodyConnector;
     $request = new HasJsonBodyRequest;
 
-    expect($connector->body()->get())->toEqual([
+    expect($connector->body()->all())->toEqual([
         'name' => 'Gareth',
         'drink' => 'Moonshine',
     ]);
 
-    expect($request->body()->get())->toEqual([
+    expect($request->body()->all())->toEqual([
         'name' => 'Sam',
         'catchphrase' => 'Yeehaw!',
     ]);
@@ -60,7 +60,7 @@ test('when both the connector and the request have the same request bodies they 
 
     expect($pendingRequestBody)->toBeInstanceOf(JsonBodyRepository::class);
 
-    expect($pendingRequestBody->get())->toEqual([
+    expect($pendingRequestBody->all())->toEqual([
         'drink' => 'Moonshine',
         'name' => 'Sam',
         'catchphrase' => 'Yeehaw!',

--- a/tests/Feature/Body/HasMultipartBodyTest.php
+++ b/tests/Feature/Body/HasMultipartBodyTest.php
@@ -16,7 +16,7 @@ use Saloon\Tests\Fixtures\Connectors\HasMultipartBodyConnector;
 test('the default body is loaded with the content type header', function () {
     $request = new HasMultipartBodyRequest();
 
-    expect($request->body()->get())->toEqual([
+    expect($request->body()->all())->toEqual([
         'nickname' => new MultipartValue('nickname', 'Sam', 'user.txt', ['X-Saloon' => 'Yee-haw!']),
     ]);
 
@@ -33,12 +33,12 @@ test('when both the connector and the request have the same request bodies they 
     $connector = new HasMultipartBodyConnector;
     $request = new HasMultipartBodyRequest;
 
-    expect($connector->body()->get())->toEqual([
+    expect($connector->body()->all())->toEqual([
         'nickname' => new MultipartValue('nickname', 'Gareth', 'user.txt', ['X-Saloon' => 'Yee-haw!']),
         'drink' => new MultipartValue('drink', 'Moonshine', 'moonshine.txt', ['X-My-Head' => 'Spinning!']),
     ]);
 
-    expect($request->body()->get())->toEqual([
+    expect($request->body()->all())->toEqual([
         'nickname' => new MultipartValue('nickname', 'Sam', 'user.txt', ['X-Saloon' => 'Yee-haw!']),
     ]);
 
@@ -49,7 +49,7 @@ test('when both the connector and the request have the same request bodies they 
 
     expect($pendingRequestBody)->toBeInstanceOf(MultipartBodyRepository::class);
 
-    expect($pendingRequestBody->get())->toEqual([
+    expect($pendingRequestBody->all())->toEqual([
         'nickname' => new MultipartValue('nickname', 'Sam', 'user.txt', ['X-Saloon' => 'Yee-haw!']),
         'drink' => new MultipartValue('drink', 'Moonshine', 'moonshine.txt', ['X-My-Head' => 'Spinning!']),
     ]);

--- a/tests/Feature/Body/HasStreamBodyTest.php
+++ b/tests/Feature/Body/HasStreamBodyTest.php
@@ -12,7 +12,7 @@ use Saloon\Tests\Fixtures\Requests\HasStreamBodyRequest;
 test('the default body is loaded', function () {
     $request = new HasStreamBodyRequest;
 
-    expect($request->body()->get())->toBeResource();
+    expect($request->body()->all())->toBeResource();
 });
 
 test('the guzzle sender properly sends it', function () {

--- a/tests/Feature/Body/HasStringBodyTest.php
+++ b/tests/Feature/Body/HasStringBodyTest.php
@@ -12,7 +12,7 @@ use Saloon\Tests\Fixtures\Requests\HasStringBodyRequest;
 test('the default body is loaded', function () {
     $request = new HasStringBodyRequest();
 
-    expect($request->body()->get())->toEqual('name: Sam');
+    expect($request->body()->all())->toEqual('name: Sam');
 });
 
 test('the guzzle sender properly sends it', function () {

--- a/tests/Feature/Body/HasXmlBodyTest.php
+++ b/tests/Feature/Body/HasXmlBodyTest.php
@@ -13,7 +13,7 @@ use Saloon\Tests\Fixtures\Requests\HasXmlBodyRequest;
 test('the default body is loaded with the content type header', function () {
     $request = new HasXmlBodyRequest();
 
-    expect($request->body()->get())->toEqual('<p>Howdy</p>');
+    expect($request->body()->all())->toEqual('<p>Howdy</p>');
 
     $connector = new TestConnector;
     $pendingRequest = $connector->createPendingRequest($request);

--- a/tests/Feature/Oauth2/ClientCredentialsFlowConnectorTest.php
+++ b/tests/Feature/Oauth2/ClientCredentialsFlowConnectorTest.php
@@ -31,7 +31,7 @@ test('you can get the authenticator from the connector', function () {
 
     $mockClient->assertSentCount(1);
 
-    expect($mockClient->getLastPendingRequest()->body()->get())->toEqual([
+    expect($mockClient->getLastPendingRequest()->body()->all())->toEqual([
         'grant_type' => 'client_credentials',
         'client_id' => 'client-id',
         'client_secret' => 'client-secret',
@@ -94,7 +94,7 @@ test('you can send scopes with the token request', function () {
 
     $mockClient->assertSentCount(1);
 
-    expect($mockClient->getLastPendingRequest()->body()->get())->toEqual([
+    expect($mockClient->getLastPendingRequest()->body()->all())->toEqual([
         'grant_type' => 'client_credentials',
         'client_id' => 'client-id',
         'client_secret' => 'client-secret',
@@ -120,7 +120,7 @@ test('default scopes on the oauth config will be merged in with the scopes on th
 
     $mockClient->assertSentCount(1);
 
-    expect($mockClient->getLastPendingRequest()->body()->get())->toEqual([
+    expect($mockClient->getLastPendingRequest()->body()->all())->toEqual([
         'grant_type' => 'client_credentials',
         'client_id' => 'client-id',
         'client_secret' => 'client-secret',
@@ -146,7 +146,7 @@ test('the scope separator can be customised', function () {
 
     $mockClient->assertSentCount(1);
 
-    expect($mockClient->getLastPendingRequest()->body()->get())->toEqual([
+    expect($mockClient->getLastPendingRequest()->body()->all())->toEqual([
         'grant_type' => 'client_credentials',
         'client_id' => 'client-id',
         'client_secret' => 'client-secret',

--- a/tests/Feature/PoolTest.php
+++ b/tests/Feature/PoolTest.php
@@ -117,7 +117,7 @@ test('you can use pool with a mock client added and it wont send real requests',
 
     $pool->withResponseHandler(function (Response $response) use (&$successCount, $mockResponses) {
         expect($response)->toBeInstanceOf(Response::class);
-        expect($response->json())->toEqual($mockResponses[$successCount]->body()->get());
+        expect($response->json())->toEqual($mockResponses[$successCount]->body()->all());
 
         $successCount++;
     });

--- a/tests/Unit/Body/ArrayBodyRepositoryTest.php
+++ b/tests/Unit/Body/ArrayBodyRepositoryTest.php
@@ -8,7 +8,7 @@ use Saloon\Repositories\Body\ArrayBodyRepository;
 test('the store is empty by default', function () {
     $body = new ArrayBodyRepository();
 
-    expect($body->get())->toEqual([]);
+    expect($body->all())->toEqual([]);
 });
 
 test('the store can have an array provided', function () {
@@ -17,7 +17,7 @@ test('the store can have an array provided', function () {
         'sidekick' => 'Mantas',
     ]);
 
-    expect($body->get())->toEqual([
+    expect($body->all())->toEqual([
         'name' => 'Sam',
         'sidekick' => 'Mantas',
     ]);
@@ -28,7 +28,7 @@ test('you can set it', function () {
 
     $body->set(['name' => 'Sam']);
 
-    expect($body->get())->toEqual(['name' => 'Sam']);
+    expect($body->all())->toEqual(['name' => 'Sam']);
 });
 
 test('it will throw an exception if you set a non-array', function () {
@@ -44,7 +44,7 @@ test('you can add an item', function () {
 
     $body->add('name', 'Sam');
 
-    expect($body->get())->toEqual(['name' => 'Sam']);
+    expect($body->all())->toEqual(['name' => 'Sam']);
 });
 
 test('you can add an item with an integer key', function () {
@@ -52,7 +52,7 @@ test('you can add an item with an integer key', function () {
 
     $body->add(1, 'Sam');
 
-    expect($body->get())->toEqual([1 => 'Sam']);
+    expect($body->all())->toEqual([1 => 'Sam']);
 });
 
 test('you can add an item without a key', function () {
@@ -60,7 +60,7 @@ test('you can add an item without a key', function () {
 
     $body->add(null, 'Sam');
 
-    expect($body->get())->toEqual(['Sam']);
+    expect($body->all())->toEqual(['Sam']);
 });
 
 test('you can conditionally add items to the array store', function () {
@@ -71,7 +71,7 @@ test('you can conditionally add items to the array store', function () {
     $body->when(true, fn (ArrayBodyRepository $body) => $body->add('sidekick', 'Mantas'));
     $body->when(false, fn (ArrayBodyRepository $body) => $body->add('sidekick', 'Teo'));
 
-    expect($body->get())->toEqual(['name' => 'Gareth', 'sidekick' => 'Mantas']);
+    expect($body->all())->toEqual(['name' => 'Gareth', 'sidekick' => 'Mantas']);
 });
 
 test('you can delete an item', function () {
@@ -80,7 +80,7 @@ test('you can delete an item', function () {
     $body->add('name', 'Sam');
     $body->remove('name');
 
-    expect($body->get())->toEqual([]);
+    expect($body->all())->toEqual([]);
 });
 
 test('you can delete an item with an integer key', function () {
@@ -89,7 +89,7 @@ test('you can delete an item with an integer key', function () {
     $body->add(1, 'Sam');
     $body->remove(1);
 
-    expect($body->get())->toEqual([]);
+    expect($body->all())->toEqual([]);
 });
 
 test('you can get an item', function () {
@@ -101,7 +101,7 @@ test('you can get an item', function () {
 
     // When omitting the key it should act like `->all()`
 
-    expect($body->get())->toEqual(['name' => 'Sam']);
+    expect($body->all())->toEqual(['name' => 'Sam']);
 });
 
 test('you can get an item with an integer key', function () {
@@ -121,7 +121,7 @@ test('you can get all items', function () {
     $allResults = ['name' => 'Sam', 'superhero' => 'Iron Man'];
 
     expect($body->all())->toEqual($allResults);
-    expect($body->get())->toEqual($allResults);
+    expect($body->all())->toEqual($allResults);
 });
 
 test('you can merge items together into the body repository', function () {
@@ -134,7 +134,7 @@ test('you can merge items together into the body repository', function () {
 
     $body->merge(['sidekick' => 'Gareth'], ['superhero' => 'Black Widow']);
 
-    expect($body->get())->toEqual(['name' => 'Sam', 'sidekick' => 'Gareth', 'superhero' => 'Black Widow']);
+    expect($body->all())->toEqual(['name' => 'Sam', 'sidekick' => 'Gareth', 'superhero' => 'Black Widow']);
 });
 
 test('you can check if the store is empty or not', function () {

--- a/tests/Unit/Body/MultipartBodyRepositoryTest.php
+++ b/tests/Unit/Body/MultipartBodyRepositoryTest.php
@@ -9,7 +9,7 @@ use Saloon\Repositories\Body\MultipartBodyRepository;
 test('the store is empty by default', function () {
     $body = new MultipartBodyRepository();
 
-    expect($body->get())->toEqual([]);
+    expect($body->all())->toEqual([]);
 });
 
 test('the store can have an array of multipart values provided', function () {
@@ -18,7 +18,7 @@ test('the store can have an array of multipart values provided', function () {
         new MultipartValue('sidekick', 'Mantas'),
     ]);
 
-    expect($body->get())->toEqual([
+    expect($body->all())->toEqual([
         'name' => new MultipartValue('name', 'Sam'),
         'sidekick' => new MultipartValue('sidekick', 'Mantas'),
     ]);
@@ -49,7 +49,7 @@ test('you can set it', function () {
         new MultipartValue('username', 'Sammyjo20'),
     ]);
 
-    expect($body->get())->toEqual([
+    expect($body->all())->toEqual([
         'username' => new MultipartValue('username', 'Sammyjo20'),
     ]);
 });
@@ -59,7 +59,7 @@ test('you can add an item', function () {
 
     $body->add('name', 'Sam', 'welcome.txt', ['a' => 'b']);
 
-    expect($body->get())->toEqual([
+    expect($body->all())->toEqual([
         'name' => new MultipartValue('name', 'Sam', 'welcome.txt', ['a' => 'b']),
     ]);
 
@@ -67,7 +67,7 @@ test('you can add an item', function () {
 
     $body->add('name', 'Charlotte', 'welcome.txt', ['a' => 'b']);
 
-    expect($body->get())->toEqual([
+    expect($body->all())->toEqual([
         'name' => new MultipartValue('name', 'Charlotte', 'welcome.txt', ['a' => 'b']),
     ]);
 });
@@ -80,7 +80,7 @@ test('you can conditionally add items to the array store', function () {
     $body->when(true, fn (MultipartBodyRepository $body) => $body->add('sidekick', 'Mantas'));
     $body->when(false, fn (MultipartBodyRepository $body) => $body->add('sidekick', 'Teo'));
 
-    expect($body->get())->toEqual([
+    expect($body->all())->toEqual([
         'name' => new MultipartValue('name', 'Gareth'),
         'sidekick' => new MultipartValue('sidekick', 'Mantas'),
     ]);
@@ -92,7 +92,7 @@ test('you can delete an item', function () {
     $body->add('name', 'Sam');
     $body->remove('name');
 
-    expect($body->get())->toEqual([]);
+    expect($body->all())->toEqual([]);
 });
 
 test('you can get an item', function () {
@@ -115,7 +115,7 @@ test('you can get all items', function () {
     ];
 
     expect($body->all())->toEqual($allResults);
-    expect($body->get())->toEqual($allResults);
+    expect($body->all())->toEqual($allResults);
 });
 
 test('you can merge items together into the body repository', function () {
@@ -128,7 +128,7 @@ test('you can merge items together into the body repository', function () {
 
     $body->merge([new MultipartValue('sidekick', 'Gareth')], [new MultipartValue('superhero', 'Black Widow')]);
 
-    expect($body->get())->toEqual([
+    expect($body->all())->toEqual([
         'name' => new MultipartValue('name', 'Sam'),
         'sidekick' => new MultipartValue('sidekick', 'Gareth'),
         'superhero' => new MultipartValue('superhero', 'Black Widow'),

--- a/tests/Unit/Body/StreamBodyRepositoryTest.php
+++ b/tests/Unit/Body/StreamBodyRepositoryTest.php
@@ -8,6 +8,7 @@ use Saloon\Repositories\Body\StreamBodyRepository;
 test('the store is empty by default', function () {
     $body = new StreamBodyRepository();
 
+    expect($body->all())->toBeNull();
     expect($body->get())->toBeNull();
 });
 
@@ -17,6 +18,7 @@ test('the store can have a default stream provided', function () {
 
     $body = new StreamBodyRepository($resource);
 
+    expect($body->all())->toEqual($resource);
     expect($body->get())->toEqual($resource);
 });
 

--- a/tests/Unit/Body/StringBodyRepositoryTest.php
+++ b/tests/Unit/Body/StringBodyRepositoryTest.php
@@ -7,14 +7,14 @@ use Saloon\Repositories\Body\StringBodyRepository;
 test('the store is empty by default', function () {
     $body = new StringBodyRepository();
 
-    expect($body->get())->toBeNull();
+    expect($body->all())->toBeNull();
 });
 
 
 test('the store can have a default string provided', function () {
     $body = new StringBodyRepository('Yeehaw!');
 
-    expect($body->get())->toEqual('Yeehaw!');
+    expect($body->all())->toEqual('Yeehaw!');
 });
 
 test('you can set it', function () {
@@ -22,7 +22,7 @@ test('you can set it', function () {
 
     $body->set('Yeehaw!');
 
-    expect($body->get())->toEqual('Yeehaw!');
+    expect($body->all())->toEqual('Yeehaw!');
 });
 
 test('you can conditionally set on the store', function () {
@@ -31,7 +31,7 @@ test('you can conditionally set on the store', function () {
     $body->when(true, fn (StringBodyRepository $body) => $body->set('Gareth'));
     $body->when(false, fn (StringBodyRepository $body) => $body->set('Sam'));
 
-    expect($body->get())->toEqual('Gareth');
+    expect($body->all())->toEqual('Gareth');
 });
 
 test('you can check if the store is empty or not', function () {

--- a/tests/Unit/MockResponseTest.php
+++ b/tests/Unit/MockResponseTest.php
@@ -28,7 +28,7 @@ test('a mock response can have raw body data', function () {
     expect($response->headers()->all())->toEqual(['Content-Type' => 'application/json']);
     expect($response->status())->toEqual(200);
     expect($response->body())->toBeInstanceOf(StringBodyRepository::class);
-    expect($response->body()->get())->toEqual('xml');
+    expect($response->body()->all())->toEqual('xml');
 });
 
 test('a response can be a custom response class', function () {

--- a/tests/Unit/PendingRequestTest.php
+++ b/tests/Unit/PendingRequestTest.php
@@ -49,7 +49,7 @@ test('the pending request validates properly formed headers', function () {
     ]);
 
     $this->expectException(InvalidHeaderException::class);
-    $this->expectExceptionMessage('One or more of the headers are invalid. Make sure to use the header name as the key. For example: \'Content-Type\' => \'application/json\'.');
+    $this->expectExceptionMessage('One or more of the headers are invalid. Make sure to use the header name as the key. For example: [\'Content-Type\' => \'application/json\'].');
 
     connector()->createPendingRequest($request);
 });


### PR DESCRIPTION
This PR must be merged after #296 as it contains changes from that branch.

This PR simply adds back the `all()` method which was previously removed. To reduce headaches and improve backwards compatibility - I have left the method in.