### PR TITLE
Fix | V3 Concurrency Issues

### DIFF
--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Traits\Connector;
 
+use GuzzleHttp\Promise\Utils;
 use LogicException;
 use Saloon\Http\Pool;
 use Saloon\Http\Request;
@@ -126,7 +127,7 @@ trait SendsRequests
         // this is great because our middleware will only run right before
         // the request is sent.
 
-        return $promise = new Promise(function () use (&$promise, $request, $mockClient, $sender) {
+        return Utils::task(function () use ($request, $mockClient, $sender) {
             $pendingRequest = $this->createPendingRequest($request, $mockClient)->setAsynchronous(true);
 
             // We need to check if the Pending Request contains a fake response.
@@ -143,11 +144,7 @@ trait SendsRequests
 
             $requestPromise->then(fn (Response $response) => $pendingRequest->executeResponsePipeline($response));
 
-            // We'll resolve the promise's value with another promise.
-            // We will use promise chaining as Guzzle's will fulfill
-            // the request promise.
-
-            $promise->resolve($requestPromise);
+            return $requestPromise;
         });
     }
 

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Saloon\Traits\Connector;
 
-use GuzzleHttp\Promise\Utils;
 use LogicException;
 use Saloon\Http\Pool;
 use Saloon\Http\Request;
 use Saloon\Http\Response;
+use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Promise\Promise;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Faking\MockClient;


### PR DESCRIPTION
I think I cracked it! 🤠🚀 This fixes a very tricky issue to get around raised in #306 

So it turns out that the way I wrote the promise wrapping before, meant that the Pool was only sending the outer promise in the concurrency specified, and the inner promise would just be invoked synchronously. After spending the last couple of nights learning properly how Guzzle's promise library works, and looking through hundreds of lines of code - I managed to stumble across our golden method. `Utils::task()`. 

As described in the docs this method: 

> Adds a function to run in the task queue when it is next `run()` and * returns a promise that is fulfilled or rejected with the result.

Looking at the code:

```php
public static function task(callable $task): PromiseInterface
{
    $queue = self::queue();
    $promise = new Promise([$queue, 'run']);
    $queue->add(function () use ($task, $promise): void {
        try {
            if (Is::pending($promise)) {
                $promise->resolve($task());
            }
        } catch (\Throwable $e) {
            $promise->reject($e);
        }
    });

    return $promise;
}
```

It's exactly what we need!

HUGE thanks to @aidan-casey for spending his Friday night looking at this issue - and helping me get to the bottom of it. 