### PR TITLE
Fix | `hasRequestFailed` method only works to mark successful requests as failures

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -336,10 +336,11 @@ class Response
     {
         $pendingRequest = $this->getPendingRequest();
 
-        $hasRequestFailed = $pendingRequest->getRequest()->hasRequestFailed($this) || $pendingRequest->getConnector()->hasRequestFailed($this);
+        $hasRequestFailedAccordingToRequest = $pendingRequest->getRequest()->hasRequestFailed($this);
+        $hasRequestFailedAccordingToConnector = $pendingRequest->getConnector()->hasRequestFailed($this);
 
-        if ($hasRequestFailed === true) {
-            return true;
+        if ($hasRequestFailedAccordingToRequest !== null || $hasRequestFailedAccordingToConnector !== null) {
+            return $hasRequestFailedAccordingToRequest || $hasRequestFailedAccordingToConnector;
         }
 
         return $this->serverError() || $this->clientError();

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -170,9 +170,10 @@ class GuzzleSender implements Sender
 
                     $response = $this->createResponse($guzzleResponse, $pendingRequest, $psrRequest, $guzzleException);
 
-                    // Throw the exception our way
+                    // Throw the exception our way if there is an exception.
+                    // Otherwise we'll return the response.
 
-                    throw $response->toException();
+                    return ($exception = $response->toException()) ? throw $exception : $response;
                 }
             );
     }

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -74,15 +74,7 @@ trait SendsRequests
 
                 $response = $pendingRequest->executeResponsePipeline($response);
 
-                // We'll check if our tries is greater than one. If it is, then we will
-                // force an exception to be thrown if the request was unsuccessful.
-                // This will then force our catch handler to retry the request.
-
-                if ($maxTries > 1) {
-                    $response->throw();
-                }
-
-                return $response;
+                return $response->throw();
             } catch (FatalRequestException|RequestException $exception) {
                 // We'll attempt to get the response from the exception. We'll only be able
                 // to do this if the exception was a "RequestException".

--- a/tests/Feature/RequestExceptionTest.php
+++ b/tests/Feature/RequestExceptionTest.php
@@ -220,6 +220,7 @@ test('you can customise if saloon determines if a request has failed on a connec
     $mockClient = new MockClient([
         MockResponse::make(['message' => 'Success']),
         MockResponse::make(['message' => 'Error: Invalid Cowboy Hat']),
+        MockResponse::make(['message' => 'Not Authenticated'], 401),
     ]);
 
     $responseA = CustomFailHandlerConnector::make()->send(new UserRequest, $mockClient);
@@ -229,12 +230,17 @@ test('you can customise if saloon determines if a request has failed on a connec
     $responseB = CustomFailHandlerConnector::make()->send(new UserRequest, $mockClient);
 
     expect($responseB->failed())->toBeTrue();
+
+    $responseC = CustomFailHandlerConnector::make()->send(new UserRequest, $mockClient);
+
+    expect($responseC->failed())->toBeFalse();
 });
 
 test('you can customise if saloon determines if a request has failed on a request', function () {
     $mockClient = new MockClient([
         MockResponse::make(['message' => 'Success']),
         MockResponse::make(['message' => 'Yee-naw: Horse Not Found']),
+        MockResponse::make(['message' => 'Not Authenticated'], 401),
     ]);
 
     $responseA = TestConnector::make()->send(new CustomFailHandlerRequest, $mockClient);
@@ -244,6 +250,10 @@ test('you can customise if saloon determines if a request has failed on a reques
     $responseB = TestConnector::make()->send(new CustomFailHandlerRequest, $mockClient);
 
     expect($responseB->failed())->toBeTrue();
+
+    $responseC = TestConnector::make()->send(new CustomFailHandlerRequest, $mockClient);
+
+    expect($responseC->failed())->toBeFalse();
 });
 
 test('the sender will throw a FatalRequestException if it cannot connect to a site using synchronous', function (string $url) {

--- a/tests/Fixtures/Requests/ErrorRequestThatShouldBeTreatedAsSuccessful.php
+++ b/tests/Fixtures/Requests/ErrorRequestThatShouldBeTreatedAsSuccessful.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+class ErrorRequestThatShouldBeTreatedAsSuccessful extends Request
+{
+    /**
+     * HTTP Method
+     */
+    protected Method $method = Method::GET;
+
+    /**
+     * Resolve the endpoint
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/not-found-error';
+    }
+
+    public function hasRequestFailed(Response $response): ?bool
+    {
+        return $response->status() !== 404;
+    }
+}


### PR DESCRIPTION
In a project, I am using an API call that returns a list of items. If there are no items, then the API call (sadly) returns a 404 response. That means I don't want an exception in that case, but just an empty collection. In my Saloon request, I implemented the `hasRequestFailed` method and I ensured it returns `false` when the response has status 404:
```php
class SomeRequest extends Request
{
    public function hasRequestFailed(Response $response): ?bool
    {
        return ($response->serverError() || $response->clientError()) && $response->status() !== 404;
    }
}
```
When I test this code, Saloon still throws an exception when I get a 404 response. That is because the current implementation of the `hasRequestFailed` method only allows you to mark successful requests as failures, but not the other way around. This PR fixes that.