### PR TITLE
Bugfix: empty response body to json should not fail

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -191,7 +191,7 @@ class Response
     public function json(string|int|null $key = null, mixed $default = null): mixed
     {
         if (! isset($this->decodedJson)) {
-            $this->decodedJson = json_decode($this->body(), true, 512, JSON_THROW_ON_ERROR);
+            $this->decodedJson = json_decode($this->body() ?: '[]', true, 512, JSON_THROW_ON_ERROR);
         }
 
         if (is_null($key)) {

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -153,7 +153,7 @@ test('the collect method will return a collection', function () {
     expect($response->collect('age'))->toBeEmpty();
 });
 
-test('the json method will empty array if body is empty', function () {
+test('the json method will return empty array if body is empty', function () {
     $mockClient = new MockClient([
         MockResponse::make('', 404),
     ]);

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -153,6 +153,16 @@ test('the collect method will return a collection', function () {
     expect($response->collect('age'))->toBeEmpty();
 });
 
+test('the json method will empty array if body is empty', function () {
+    $mockClient = new MockClient([
+        MockResponse::make('', 404),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+
+    expect($response->json())->toBe([]);
+});
+
 test('the toPsrResponse method will return a guzzle response', function () {
     $mockClient = new MockClient([
         MockResponse::make(['name' => 'Sam', 'work' => 'Codepotato'], 500),


### PR DESCRIPTION
Similar to Laravel's Http Client Response, the `json()` method on a response should not throw an exception when the body is empty.