### PR TITLE
Fix: remove empty parameters from authorization url

### DIFF
--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -46,14 +46,14 @@ trait AuthorizationCodeGrant
 
         $this->state = $state ?? StringHelpers::random(32);
 
-        $queryParameters = [
+        $queryParameters = array_filter([
             'response_type' => 'code',
-            'scope' => implode($scopeSeparator, array_merge($defaultScopes, $scopes)),
+            'scope' => implode($scopeSeparator, array_filter(array_merge($defaultScopes, $scopes))),
             'client_id' => $clientId,
             'redirect_uri' => $redirectUri,
             'state' => $this->state,
             ...$additionalQueryParameters,
-        ];
+        ]);
 
         $query = http_build_query($queryParameters, '', '&', PHP_QUERY_RFC3986);
         $query = trim($query, '?&');

--- a/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
+++ b/tests/Feature/Oauth2/AuthCodeFlowConnectorTest.php
@@ -50,6 +50,18 @@ test('you can provide default scopes that will be applied to every authorization
     );
 });
 
+test('you can get authorization url without setting valid scopes', function () {
+    $connector = new OAuth2Connector;
+
+    $connector->oauthConfig()->setDefaultScopes(['', null]);
+
+    $url = $connector->getAuthorizationUrl([], 'my-state');
+
+    expect($url)->toEqual(
+        'https://oauth.saloon.dev/authorize?response_type=code&client_id=client-id&redirect_uri=https%3A%2F%2Fmy-app.saloon.dev%2Fauth%2Fcallback&state=my-state'
+    );
+});
+
 test('default state is generated automatically with every authorization url if state is not defined', function () {
     $connector = new OAuth2Connector;
 


### PR DESCRIPTION
This (PR) aims to remove empty parameters from the authorization URL when trying to authenticate on the **Mercado Livre** platform, which uses the **OAuth 2** standard. When a URL with empty parameters is generated, an error occurs. For example, when the **'scope'** parameter is empty.

Before:

https://oauth.saloon.dev/authorize?response_type=code&scope=&client_id=client-id&redirect_uri=https%3A%2F%2Fmy-app.saloon.dev%2Fauth%2Fcallback&state=my-state

After:

https://oauth.saloon.dev/authorize?response_type=code&client_id=client-id&redirect_uri=https%3A%2F%2Fmy-app.saloon.dev%2Fauth%2Fcallback&state=my-state