### PR TITLE
Feature | Add header authenticator class

### DIFF
--- a/src/Http/Auth/HeaderAuthenticator.php
+++ b/src/Http/Auth/HeaderAuthenticator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Http\Auth;
+
+use Saloon\Http\PendingRequest;
+use Saloon\Contracts\Authenticator;
+
+class HeaderAuthenticator implements Authenticator
+{
+    /**
+     * Constructor
+     */
+    public function __construct(
+        public string $accessToken,
+        public string $headerName = 'Authorization',
+    ) {
+        //
+    }
+
+    /**
+     * Apply the authentication to the request.
+     */
+    public function set(PendingRequest $pendingRequest): void
+    {
+        $pendingRequest->headers()->add($this->headerName, $this->accessToken);
+    }
+}

--- a/src/Traits/Auth/AuthenticatesRequests.php
+++ b/src/Traits/Auth/AuthenticatesRequests.php
@@ -6,10 +6,10 @@ namespace Saloon\Traits\Auth;
 
 use Saloon\Contracts\Authenticator;
 use Saloon\Http\Auth\BasicAuthenticator;
-use Saloon\Http\Auth\HeaderAuthenticator;
 use Saloon\Http\Auth\QueryAuthenticator;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Auth\DigestAuthenticator;
+use Saloon\Http\Auth\HeaderAuthenticator;
 
 trait AuthenticatesRequests
 {

--- a/src/Traits/Auth/AuthenticatesRequests.php
+++ b/src/Traits/Auth/AuthenticatesRequests.php
@@ -6,6 +6,7 @@ namespace Saloon\Traits\Auth;
 
 use Saloon\Contracts\Authenticator;
 use Saloon\Http\Auth\BasicAuthenticator;
+use Saloon\Http\Auth\HeaderAuthenticator;
 use Saloon\Http\Auth\QueryAuthenticator;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Auth\DigestAuthenticator;
@@ -83,5 +84,15 @@ trait AuthenticatesRequests
     public function withQueryAuth(string $parameter, string $value): static
     {
         return $this->authenticate(new QueryAuthenticator($parameter, $value));
+    }
+
+    /**
+     * Authenticate the request with a header.
+     *
+     * @return $this
+     */
+    public function withHeaderAuth(string $accessToken, string $headerName = 'Authorization'): static
+    {
+        return $this->authenticate(new HeaderAuthenticator($accessToken, $headerName));
     }
 }

--- a/tests/Unit/AuthenticatesRequestsTest.php
+++ b/tests/Unit/AuthenticatesRequestsTest.php
@@ -52,3 +52,12 @@ test('you can add a token to a query parameter', function () {
 
     expect($query)->toHaveKey('token', 'Sammyjo20');
 });
+
+test('you can add a header to a request', function () {
+    $request = UserRequest::make()->withHeaderAuth('Sammyjo20', 'X-Authorization');
+
+    $pendingRequest = connector()->createPendingRequest($request);
+    $query = $pendingRequest->headers()->all();
+
+    expect($query)->toHaveKey('X-Authorization', 'Sammyjo20');
+});


### PR DESCRIPTION
I have to consume some weird API's in one of my projects at work. That's why I figured a more general header authenticator class could be of good use. I'm using this one as a custom authenticator in my project right now but I wanted to share it in the case someone else could use it as well.

I couldn't find any dedicated authenticator tests, so I only added the helper method in the `AuthenticatesRequests` trait to keep it consistent with the rest. If I'm missing anything, please let me know. Feel free to close the MR if this kind of authenticator is not desirable in Saloon.