### PR TITLE
Fix | MockClient assertions with fixtures

### DIFF
--- a/src/Http/Middleware/DetermineMockResponse.php
+++ b/src/Http/Middleware/DetermineMockResponse.php
@@ -53,7 +53,7 @@ class DetermineMockResponse implements RequestMiddleware
         // middleware on the response to record the response.
 
         if (is_null($mockResponse) && $mockObject instanceof Fixture) {
-            $pendingRequest->middleware()->onResponse(new RecordFixture($mockObject), 'recordFixture', PipeOrder::FIRST);
+            $pendingRequest->middleware()->onResponse(new RecordFixture($mockObject, $mockClient), 'recordFixture', PipeOrder::FIRST);
         }
 
         return $pendingRequest;

--- a/src/Http/Middleware/RecordFixture.php
+++ b/src/Http/Middleware/RecordFixture.php
@@ -7,6 +7,7 @@ namespace Saloon\Http\Middleware;
 use Saloon\Http\Response;
 use Saloon\Http\Faking\Fixture;
 use Saloon\Data\RecordedResponse;
+use Saloon\Http\Faking\MockClient;
 use Saloon\Contracts\ResponseMiddleware;
 
 class RecordFixture implements ResponseMiddleware
@@ -17,11 +18,17 @@ class RecordFixture implements ResponseMiddleware
     protected Fixture $fixture;
 
     /**
+     * Mock Client
+     */
+    protected MockClient $mockClient;
+
+    /**
      * Constructor
      */
-    public function __construct(Fixture $fixture)
+    public function __construct(Fixture $fixture, MockClient $mockClient)
     {
         $this->fixture = $fixture;
+        $this->mockClient = $mockClient;
     }
 
     /**
@@ -37,5 +44,7 @@ class RecordFixture implements ResponseMiddleware
         $this->fixture->store(
             RecordedResponse::fromResponse($response)
         );
+
+        $this->mockClient->recordResponse($response);
     }
 }

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -729,3 +729,13 @@ test('request and response middleware is invoked when using fake responses', fun
     expect($middlewareC)->toBeTrue();
     expect($middlewareD)->toBeTrue();
 });
+
+test('fixtures are still recorded on the first request', function () {
+    $mockClient = new MockClient([
+        MockResponse::fixture('user'), // Test Exact Route
+    ]);
+
+    connector()->send(new UserRequest, $mockClient);
+
+    $mockClient->assertSent(UserRequest::class);
+});


### PR DESCRIPTION
This PR fixes an issue with the `MockClient` assertions when a fixture doesn't exist. Methods on the `MockClient` like `assertSent` would use an array of `recordedResponses` which were previously only recorded after creating a mock-response. When using fixtures, because the first request that was sent was not a `MockResponse`, it was never being recorded. This PR changes Saloon so fixtures are recorded to the mock client.

This should resolve #322.