### PR TITLE
Fix | Merge the headers from the Connector into the `PendingRequest` when mocking

### DIFF
--- a/src/Traits/Connector/ManagesFakeResponses.php
+++ b/src/Traits/Connector/ManagesFakeResponses.php
@@ -6,6 +6,7 @@ namespace Saloon\Traits\Connector;
 
 use Throwable;
 use Saloon\Http\Response;
+use GuzzleHttp\RequestOptions;
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\FakeResponse;
 use Saloon\Http\Faking\MockResponse;
@@ -24,6 +25,11 @@ trait ManagesFakeResponses
      */
     protected function createFakeResponse(PendingRequest $pendingRequest): Response|PromiseInterface
     {
+        // Merge the headers from the connector config
+        $pendingRequest->headers()->merge(
+            $this->config()->get(RequestOptions::HEADERS, [])
+        );
+
         $fakeResponse = $pendingRequest->getFakeResponse();
 
         if (! $fakeResponse instanceof FakeResponse) {

--- a/tests/Feature/MockRequestTest.php
+++ b/tests/Feature/MockRequestTest.php
@@ -19,6 +19,7 @@ use Saloon\Exceptions\NoMockResponseFoundException;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Tests\Fixtures\Mocking\RegexUserFixture;
 use Saloon\Tests\Fixtures\Mocking\SuperheroFixture;
+use Saloon\Tests\Fixtures\Connectors\HeaderConnector;
 use Saloon\Tests\Fixtures\Mocking\MissingNameFixture;
 use Saloon\Tests\Fixtures\Requests\AlwaysThrowRequest;
 use Saloon\Tests\Fixtures\Mocking\CallableMockResponse;
@@ -738,4 +739,17 @@ test('fixtures are still recorded on the first request', function () {
     connector()->send(new UserRequest, $mockClient);
 
     $mockClient->assertSent(UserRequest::class);
+});
+
+test('a mocked request has the headers from the connector', function () {
+    $mockClient = new MockClient([
+        UserRequest::class => MockResponse::make()
+    ]);
+
+    $connector = new HeaderConnector;
+    $connector->withMockClient($mockClient);
+
+    $responseA = $connector->send(new UserRequest);
+
+    expect($responseA->getPsrRequest()->getHeader('X-Connector-Header'))->toBe(['Sam']);
 });


### PR DESCRIPTION
Hey again! 👋 This PR provides a similar fix as https://github.com/saloonphp/laravel-http-sender/pull/14.

When working with mocks, the headers from the connector are not merged into the `PendingRequest` instance. We are using the `createPsrRequest()` method on this instance to do some logging and saw the headers missing. This PR fixes that.