### PR TITLE
Feature | Adding `withRequestMocks()` helper + introducing `HasFakeData` interface

### DIFF
--- a/src/Contracts/HasFakeData.php
+++ b/src/Contracts/HasFakeData.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Contracts;
+
+use Saloon\Http\PendingRequest;
+
+interface HasFakeData
+{
+    /**
+     * Get the fake data for the mocked request.
+     */
+    public function getFakeData(PendingRequest $request): mixed;
+}

--- a/src/Contracts/HasFakeData.php
+++ b/src/Contracts/HasFakeData.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Saloon\Contracts;
 
+use Saloon\Http\Faking\Fixture;
 use Saloon\Http\PendingRequest;
+use Saloon\Http\Faking\MockResponse;
 
 interface HasFakeData
 {
     /**
      * Get the fake data for the mocked request.
+     *
+     * @return array<mixed,mixed>|string|MockResponse|Fixture
      */
-    public function getFakeData(PendingRequest $request): mixed;
+    public function getFakeData(PendingRequest $request): array|string|MockResponse|Fixture;
 }

--- a/src/Traits/HasMockClient.php
+++ b/src/Traits/HasMockClient.php
@@ -47,6 +47,8 @@ trait HasMockClient
      * Mocks the given requests with the given responses, or with the
      * mocked response from the 'getFakeData()' method if the
      * request has implemented the HasFakeData interface.
+     *
+     * @param array<array-key|class-string, mixed> $requestMocks
      */
     public function withRequestMocks(array $requestMocks): static
     {
@@ -67,9 +69,13 @@ trait HasMockClient
             }];
         })->all();
 
-        return $this->hasMockClient()
-            ? $this->getMockClient()->addResponses($responses)
-            : $this->withMockClient(new MockClient($responses));
+        if ($this->hasMockClient()) {
+            $this->getMockClient()->addResponses($responses);
+
+            return $this;
+        }
+
+        return $this->withMockClient(new MockClient($responses));
     }
 
     /**

--- a/src/Traits/HasMockClient.php
+++ b/src/Traits/HasMockClient.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Saloon\Traits;
 
+use Saloon\Http\Faking\Fixture;
+use Saloon\Http\PendingRequest;
+use Saloon\Contracts\HasFakeData;
 use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
 
 trait HasMockClient
 {
@@ -23,6 +27,49 @@ trait HasMockClient
         $this->mockClient = $mockClient;
 
         return $this;
+    }
+
+    /**
+     * Creates a MockResponse instance from the given value if
+     * it is a string or an array. Otherwise, it returns the
+     * value as is.
+     */
+    private function prepareMockResponse(mixed $value): MockResponse|Fixture|callable
+    {
+        if (is_array($value) || is_string($value)) {
+            return new MockResponse($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Mocks the given requests with the given responses, or with the
+     * mocked response from the 'getFakeData()' method if the
+     * request has implemented the HasFakeData interface.
+     */
+    public function withRequestMocks(array $requestMocks): static
+    {
+        $responses = collect($requestMocks)->mapWithKeys(function (mixed $value, int|string $key) {
+            // Something like: [UserRequest::class => MockResponse::fixture('user')];
+            // Or URL mocking: ['/user' => ['id' => 123];
+            if (! is_numeric($key)) {
+                return [$key => $this->prepareMockResponse($value)];
+            }
+
+            // Just the Request class name or the URL. Retrieve the fake data from the request.
+            return [$value => function (PendingRequest $pendingRequest) {
+                $request = $pendingRequest->getRequest();
+
+                return $request instanceof HasFakeData
+                    ? $this->prepareMockResponse($request->getFakeData($pendingRequest))
+                    : MockResponse::make();
+            }];
+        })->all();
+
+        return $this->hasMockClient()
+            ? $this->getMockClient()->addResponses($responses)
+            : $this->withMockClient(new MockClient($responses));
     }
 
     /**

--- a/tests/Feature/HasMockClientTest.php
+++ b/tests/Feature/HasMockClientTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Saloon\MockConfig;
+use Saloon\Http\PendingRequest;
+use League\Flysystem\Filesystem;
+use Saloon\Http\Faking\MockResponse;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\Requests\SoloUserRequest;
+use Saloon\Tests\Fixtures\Requests\UserRequestWithFakeData;
+use Saloon\Tests\Fixtures\Requests\UserRequestWithFakeDataFixture;
+
+$filesystem = new Filesystem(new LocalFilesystemAdapter('tests/Fixtures/Saloon/Testing'));
+
+beforeEach(function () use ($filesystem) {
+    MockConfig::setFixturePath('tests/Fixtures/Saloon/Testing');
+
+    $filesystem->deleteDirectory('/');
+    $filesystem->createDirectory('/');
+});
+
+afterEach(function () {
+    MockConfig::setFixturePath('tests/Fixtures/Saloon');
+});
+
+it('can mock a request with a string', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequest::class => 'Sam',
+    ]);
+
+    $response = $connector->send(new UserRequest);
+    expect($response->body())->toEqual('Sam');
+});
+
+it('can mock a request with an array', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequest::class => ['Sam'],
+    ]);
+
+    $response = $connector->send(new UserRequest);
+    expect($response->json())->toEqual(['Sam']);
+});
+
+it('can mock a request with a MockResponse instance', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequest::class => MockResponse::make(['Sam']),
+    ]);
+
+    $response = $connector->send(new UserRequest);
+    expect($response->json())->toEqual(['Sam']);
+});
+
+it('can mock a request with a Fixture instance', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequest::class => MockResponse::fixture('user'),
+    ]);
+
+    $response = $connector->send(new UserRequest);
+    expect($response->json())->toEqual([
+        'name' => 'Sammyjo20',
+        'actual_name' => 'Sam',
+        'twitter' => '@carre_sam',
+    ]);
+});
+
+it('can mock a request with a callback', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequest::class => fn (PendingRequest $pendingRequest) => MockResponse::fixture('user'),
+    ]);
+
+    $response = $connector->send(new UserRequest);
+    expect($response->json())->toEqual([
+        'name' => 'Sammyjo20',
+        'actual_name' => 'Sam',
+        'twitter' => '@carre_sam',
+    ]);
+});
+
+it('can mock a URL instead of a request class', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        '/user' => ['Sam'],
+    ]);
+
+    $response = $connector->send(new UserRequest);
+    expect($response->json())->toEqual(['Sam']);
+});
+
+
+test('a request can implement the HasFakeData interface that returns an array', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequestWithFakeData::class,
+    ]);
+
+    $response = $connector->send(new UserRequestWithFakeData);
+    expect($response->json())->toEqual(['Sam']);
+});
+
+test('a request can implement the HasFakeData interface that returns a Fixture', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequestWithFakeDataFixture::class,
+    ]);
+
+    $response = $connector->send(new UserRequestWithFakeDataFixture);
+    expect($response->json())->toEqual([
+        'name' => 'Sammyjo20',
+        'actual_name' => 'Sam',
+        'twitter' => '@carre_sam',
+    ]);
+});
+
+it('can mix requests that implement the HasFakeData interface with inline mocks', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequestWithFakeDataFixture::class,
+        UserRequest::class => ['Sam'],
+    ]);
+
+    $responseA = $connector->send(new UserRequestWithFakeDataFixture);
+    expect($responseA->json())->toEqual([
+        'name' => 'Sammyjo20',
+        'actual_name' => 'Sam',
+        'twitter' => '@carre_sam',
+    ]);
+
+    $responseB = $connector->send(new UserRequest);
+    expect($responseB->json())->toEqual(['Sam']);
+});
+
+it('can mock a request that does not implement the HasFakeData interface', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        SoloUserRequest::class,
+    ]);
+
+    $response = $connector->send(new SoloUserRequest);
+    expect($response->status())->toEqual(200);
+    expect($response->json())->toEqual([]);
+});

--- a/tests/Feature/HasMockClientTest.php
+++ b/tests/Feature/HasMockClientTest.php
@@ -137,3 +137,18 @@ it('can mock a request that does not implement the HasFakeData interface', funct
     expect($response->status())->toEqual(200);
     expect($response->json())->toEqual([]);
 });
+
+it('can call the withRequestMocks twice without losing any mocks', function () {
+    $connector = TestConnector::make()->withRequestMocks([
+        UserRequest::class => ['Sam'],
+    ])->withRequestMocks([
+        SoloUserRequest::class,
+    ]);
+
+    $responseA = $connector->send(new UserRequest);
+    expect($responseA->json())->toEqual(['Sam']);
+
+    $responseB = $connector->send(new SoloUserRequest);
+    expect($responseB->status())->toEqual(200);
+    expect($responseB->json())->toEqual([]);
+});

--- a/tests/Fixtures/Requests/UserRequestWithFakeData.php
+++ b/tests/Fixtures/Requests/UserRequestWithFakeData.php
@@ -6,8 +6,10 @@ namespace Saloon\Tests\Fixtures\Requests;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Http\Faking\Fixture;
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\HasFakeData;
+use Saloon\Http\Faking\MockResponse;
 
 class UserRequestWithFakeData extends Request implements HasFakeData
 {
@@ -27,7 +29,7 @@ class UserRequestWithFakeData extends Request implements HasFakeData
     /**
      * Get the fake data for the mocked request.
      */
-    public function getFakeData(PendingRequest $request): mixed
+    public function getFakeData(PendingRequest $request): array|string|MockResponse|Fixture
     {
         return ['Sam'];
     }

--- a/tests/Fixtures/Requests/UserRequestWithFakeData.php
+++ b/tests/Fixtures/Requests/UserRequestWithFakeData.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\PendingRequest;
+use Saloon\Contracts\HasFakeData;
+
+class UserRequestWithFakeData extends Request implements HasFakeData
+{
+    /**
+     * Define the HTTP method.
+     */
+    protected Method $method = Method::GET;
+
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/user';
+    }
+
+    /**
+     * Get the fake data for the mocked request.
+     */
+    public function getFakeData(PendingRequest $request): mixed
+    {
+        return ['Sam'];
+    }
+}

--- a/tests/Fixtures/Requests/UserRequestWithFakeDataFixture.php
+++ b/tests/Fixtures/Requests/UserRequestWithFakeDataFixture.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\PendingRequest;
+use Saloon\Contracts\HasFakeData;
+use Saloon\Http\Faking\MockResponse;
+
+class UserRequestWithFakeDataFixture extends Request implements HasFakeData
+{
+    /**
+     * Define the HTTP method.
+     */
+    protected Method $method = Method::GET;
+
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/user';
+    }
+
+    /**
+     * Get the fake data for the mocked request.
+     */
+    public function getFakeData(PendingRequest $request): mixed
+    {
+        return MockResponse::fixture('user');
+    }
+}

--- a/tests/Fixtures/Requests/UserRequestWithFakeDataFixture.php
+++ b/tests/Fixtures/Requests/UserRequestWithFakeDataFixture.php
@@ -6,6 +6,7 @@ namespace Saloon\Tests\Fixtures\Requests;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Http\Faking\Fixture;
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\HasFakeData;
 use Saloon\Http\Faking\MockResponse;
@@ -28,7 +29,7 @@ class UserRequestWithFakeDataFixture extends Request implements HasFakeData
     /**
      * Get the fake data for the mocked request.
      */
-    public function getFakeData(PendingRequest $request): mixed
+    public function getFakeData(PendingRequest $request): array|string|MockResponse|Fixture
     {
         return MockResponse::fixture('user');
     }


### PR DESCRIPTION
This PR consists of two new features. I worked on it with @onlime, credits to him for the idea!

**Request Mocks**

The first feature is a `withRequestMocks()` method that you may call, for example, on a `Connector`. You may use both Request class names and URLs. Under the hood, it transforms the array into an array of mock responses that are passed to the `MockClient`. Also, you may now pass arrays and strings in addition to using `MockResponse`/`Fixture` instances and callbacks.

```php
ForgeConnector::make()->withRequestMocks([
    GetUserRequest::class => 'Sam',
    GetServersRequest::class => ['Server A', 'Server B'],
    OtherServiceRequest::class => MockResponse::fixture('other-service'),
    WildcardServiceRequest::class => fn (PendingRequest $pendingRequest) => MockResponse::make(['...'])
    
    // or...

    '/user/1' => 'Sam',
    '/servers' => ['Server A', 'Server B'],
]);
```

If you don't provide a response, it simply uses an empty `MockResponse`:

**`HasFakeData` interface**

The second feature is a `HasFakeData` interface that you may use on a Request class. Also here, you may return a string, an array, or a `MockResponse` or `Fixture` instance:

```php
use Saloon\Enums\Method;
use Saloon\Http\Request;
use Saloon\Http\PendingRequest;
use Saloon\Contracts\HasFakeData;

class GetUserRequest extends Request implements HasFakeData
{
    /**
     * Define the HTTP method.
     */
    protected Method $method = Method::GET;

    /**
     * Define the endpoint for the request.
     */
    public function resolveEndpoint(): string
    {
        return '/user';
    }

    /**
     * Get the fake data for the mocked request.
     */
    public function getFakeData(PendingRequest $request): mixed
    {
        return ['Sam'];
    }
}
```

Now when you pass the request to the `withRequestMocks` method, it will use the `getFakeData` method to mock the response:

```php
ForgeConnector::make()->withRequestMocks([
    GetUserRequest::class,
]);
```

You may even mix requests with and without this interface, as well as URLs:

```php
ForgeConnector::make()->withRequestMocks([
    GetUserRequest::class,
    GetServersRequest::class => ['Server A', 'Server B'],
    '/meta' => ['status' => 'pending'],
]);
```