### PR TITLE
Fix | V3 - Remove array filter on multipart builder

### DIFF
--- a/src/Http/Senders/Factories/GuzzleMultipartBodyFactory.php
+++ b/src/Http/Senders/Factories/GuzzleMultipartBodyFactory.php
@@ -20,12 +20,12 @@ class GuzzleMultipartBodyFactory implements MultipartBodyFactory
     public function create(StreamFactoryInterface $streamFactory, array $multipartValues, string $boundary): StreamInterface
     {
         $elements = array_map(static function (MultipartValue $value) {
-            return array_filter([
+            return [
                 'name' => $value->name,
                 'filename' => $value->filename,
                 'contents' => $value->value,
                 'headers' => $value->headers,
-            ]);
+            ];
         }, $multipartValues);
 
         return new MultipartStream($elements, $boundary);

--- a/tests/Feature/Body/HasMultipartBodyTest.php
+++ b/tests/Feature/Body/HasMultipartBodyTest.php
@@ -10,6 +10,7 @@ use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Promise\FulfilledPromise;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Repositories\Body\MultipartBodyRepository;
+use Saloon\Tests\Fixtures\Requests\MixedMultipartRequest;
 use Saloon\Tests\Fixtures\Requests\HasMultipartBodyRequest;
 use Saloon\Tests\Fixtures\Connectors\HasMultipartBodyConnector;
 
@@ -87,4 +88,34 @@ test('the guzzle sender properly sends it', function () {
     $connector->send($request);
 
     expect($asserted)->toBeTrue();
+});
+
+test('can send a real multipart request and files are sent', function () {
+    $connector = new TestConnector;
+    $request = new MixedMultipartRequest;
+
+    $request->body()->add('name', 'Howdy');
+    $request->body()->add('file', file_get_contents('tests/Fixtures/Howdy.txt'), 'hi.txt');
+
+    $response = $connector->send($request);
+
+    $data = $response->json();
+
+    expect($data)->toHaveKey('name', 'Howdy');
+    expect($data)->toHaveKey('file_contents', 'Hello World!' . PHP_EOL);
+});
+
+test('can send an empty string as the contents', function () {
+    $connector = new TestConnector;
+    $request = new MixedMultipartRequest;
+
+    $request->body()->add('name', 'Howdy');
+    $request->body()->add('file', '', 'hi.txt');
+
+    $response = $connector->send($request);
+
+    $data = $response->json();
+
+    expect($data)->toHaveKey('name', 'Howdy');
+    expect($data)->toHaveKey('file_contents', '');
 });

--- a/tests/Fixtures/Howdy.txt
+++ b/tests/Fixtures/Howdy.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/tests/Fixtures/Requests/MixedMultipartRequest.php
+++ b/tests/Fixtures/Requests/MixedMultipartRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Traits\Body\HasMultipartBody;
+
+class MixedMultipartRequest extends Request implements HasBody
+{
+    use HasMultipartBody;
+
+    protected Method $method = Method::POST;
+
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/mixed-multipart';
+    }
+}


### PR DESCRIPTION
Fixes #331 

Sometimes APIs will accept an empty string or `null` for the contents of Multipart Values. Previously if you had tried to provide an empty string, you would get an error from Guzzle. This was because of an `array_filter()` that I had added previously. 

I have now also written a real-world test that makes an API call to our test service to ensure real uploads work.