### PR TITLE
Fix | V3 - Allow multiple multipart values with the same name

### DIFF
--- a/src/Repositories/Body/ArrayBodyRepository.php
+++ b/src/Repositories/Body/ArrayBodyRepository.php
@@ -6,6 +6,7 @@ namespace Saloon\Repositories\Body;
 
 use LogicException;
 use InvalidArgumentException;
+use Saloon\Helpers\ArrayHelpers;
 use Saloon\Traits\Conditionable;
 use Psr\Http\Message\StreamInterface;
 use Saloon\Contracts\Body\MergeableBody;
@@ -102,7 +103,7 @@ class ArrayBodyRepository implements BodyRepository, MergeableBody
             return $this->all();
         }
 
-        return $this->all()[$key] ?? $default;
+        return ArrayHelpers::get($this->all(), $key, $default);
     }
 
     /**

--- a/src/Repositories/Body/ArrayBodyRepository.php
+++ b/src/Repositories/Body/ArrayBodyRepository.php
@@ -6,7 +6,6 @@ namespace Saloon\Repositories\Body;
 
 use LogicException;
 use InvalidArgumentException;
-use Saloon\Helpers\ArrayHelpers;
 use Saloon\Traits\Conditionable;
 use Psr\Http\Message\StreamInterface;
 use Saloon\Contracts\Body\MergeableBody;
@@ -103,7 +102,7 @@ class ArrayBodyRepository implements BodyRepository, MergeableBody
             return $this->all();
         }
 
-        return ArrayHelpers::get($this->all(), $key, $default);
+        return $this->all()[$key] ?? $default;
     }
 
     /**

--- a/src/Repositories/Body/MultipartBodyRepository.php
+++ b/src/Repositories/Body/MultipartBodyRepository.php
@@ -6,7 +6,6 @@ namespace Saloon\Repositories\Body;
 
 use InvalidArgumentException;
 use Saloon\Data\MultipartValue;
-use Saloon\Helpers\ArrayHelpers;
 use Saloon\Traits\Conditionable;
 use Saloon\Helpers\StringHelpers;
 use Saloon\Exceptions\BodyException;

--- a/src/Repositories/Body/MultipartBodyRepository.php
+++ b/src/Repositories/Body/MultipartBodyRepository.php
@@ -123,6 +123,7 @@ class MultipartBodyRepository implements BodyRepository, MergeableBody
      * Get a specific key of the array
      *
      * @param array-key $key
+     * @return MultipartValue|array<MultipartValue>
      */
     public function get(string|int $key, mixed $default = null): MultipartValue|array
     {

--- a/tests/Unit/Body/MultipartBodyRepositoryTest.php
+++ b/tests/Unit/Body/MultipartBodyRepositoryTest.php
@@ -19,8 +19,8 @@ test('the store can have an array of multipart values provided', function () {
     ]);
 
     expect($body->all())->toEqual([
-        'name' => new MultipartValue('name', 'Sam'),
-        'sidekick' => new MultipartValue('sidekick', 'Mantas'),
+        new MultipartValue('name', 'Sam'),
+        new MultipartValue('sidekick', 'Mantas'),
     ]);
 });
 
@@ -50,30 +50,31 @@ test('you can set it', function () {
     ]);
 
     expect($body->all())->toEqual([
-        'username' => new MultipartValue('username', 'Sammyjo20'),
+        new MultipartValue('username', 'Sammyjo20'),
     ]);
 });
 
-test('you can add an item', function () {
-    $body = new MultipartBodyRepository();
+test('you can add multiple items', function () {
+    $body = new MultipartBodyRepository;
 
     $body->add('name', 'Sam', 'welcome.txt', ['a' => 'b']);
 
     expect($body->all())->toEqual([
-        'name' => new MultipartValue('name', 'Sam', 'welcome.txt', ['a' => 'b']),
+        new MultipartValue('name', 'Sam', 'welcome.txt', ['a' => 'b']),
     ]);
 
-    // Test it being overwritten
+    // Test it gets added to the array
 
     $body->add('name', 'Charlotte', 'welcome.txt', ['a' => 'b']);
 
     expect($body->all())->toEqual([
-        'name' => new MultipartValue('name', 'Charlotte', 'welcome.txt', ['a' => 'b']),
+        new MultipartValue('name', 'Sam', 'welcome.txt', ['a' => 'b']),
+        new MultipartValue('name', 'Charlotte', 'welcome.txt', ['a' => 'b']),
     ]);
 });
 
 test('you can conditionally add items to the array store', function () {
-    $body = new MultipartBodyRepository();
+    $body = new MultipartBodyRepository;
 
     $body->when(true, fn (MultipartBodyRepository $body) => $body->add('name', 'Gareth'));
     $body->when(false, fn (MultipartBodyRepository $body) => $body->add('name', 'Sam'));
@@ -81,8 +82,8 @@ test('you can conditionally add items to the array store', function () {
     $body->when(false, fn (MultipartBodyRepository $body) => $body->add('sidekick', 'Teo'));
 
     expect($body->all())->toEqual([
-        'name' => new MultipartValue('name', 'Gareth'),
-        'sidekick' => new MultipartValue('sidekick', 'Mantas'),
+        new MultipartValue('name', 'Gareth'),
+        new MultipartValue('sidekick', 'Mantas'),
     ]);
 });
 
@@ -110,8 +111,8 @@ test('you can get all items', function () {
     $body->add('superhero', 'Iron Man');
 
     $allResults = [
-        'name' => new MultipartValue('name', 'Sam'),
-        'superhero' => new MultipartValue('superhero', 'Iron Man'),
+        new MultipartValue('name', 'Sam'),
+        new MultipartValue('superhero', 'Iron Man'),
     ];
 
     expect($body->all())->toEqual($allResults);
@@ -129,9 +130,10 @@ test('you can merge items together into the body repository', function () {
     $body->merge([new MultipartValue('sidekick', 'Gareth')], [new MultipartValue('superhero', 'Black Widow')]);
 
     expect($body->all())->toEqual([
-        'name' => new MultipartValue('name', 'Sam'),
-        'sidekick' => new MultipartValue('sidekick', 'Gareth'),
-        'superhero' => new MultipartValue('superhero', 'Black Widow'),
+        new MultipartValue('name', 'Sam'),
+        new MultipartValue('sidekick', 'Mantas'),
+        new MultipartValue('sidekick', 'Gareth'),
+        new MultipartValue('superhero', 'Black Widow'),
     ]);
 });
 

--- a/tests/Unit/Body/MultipartBodyRepositoryTest.php
+++ b/tests/Unit/Body/MultipartBodyRepositoryTest.php
@@ -104,6 +104,18 @@ test('you can get an item', function () {
     expect($body->get('name'))->toEqual(new MultipartValue('name', 'Sam'));
 });
 
+test('you can get multiple items with the same name', function () {
+    $body = new MultipartBodyRepository();
+
+    $body->add('name', 'Sam');
+    $body->add('name', 'Alex');
+
+    expect($body->get('name'))->toEqual([
+        new MultipartValue('name', 'Sam'),
+        new MultipartValue('name', 'Alex'),
+    ]);
+});
+
 test('you can get all items', function () {
     $body = new MultipartBodyRepository();
 


### PR DESCRIPTION
This PR fixes #338 #254

I'm aware that this PR **technically** introduces a breaking change in the way multipart values are keyed behind the scenes. I'm going to proceed with this PR as this fixes an issue that multiple people have been experiencing and the breaking change is unlikely to affect the end user. I take breaking changes very seriously but decided to go with this one.