### PR TITLE
Fix exponential backoff attribute

### DIFF
--- a/src/Traits/RequestProperties/HasTries.php
+++ b/src/Traits/RequestProperties/HasTries.php
@@ -31,7 +31,7 @@ trait HasTries
      *
      * When true, Saloon will double the retry interval after each attempt.
      */
-    public bool $useExponentialBackoff = false;
+    public ?bool $useExponentialBackoff = null;
 
     /**
      * Should Saloon throw an exception after exhausting the maximum number of retries?


### PR DESCRIPTION
`$useExponentialBackoff` needs to be defined as `null`, as otherwise when `$useExponentialBackoff` is only specified at the connector level, this line:

`$useExponentialBackoff = $request->useExponentialBackoff ?? $this->useExponentialBackoff ?? false;`

will evaluate `false`, as it has default `false` value for the request class (inherited from `HasTries` trait)