### PR TITLE
Feature | Throw an exception when missing HTTP method

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Http;
 
+use LogicException;
 use Saloon\Enums\Method;
 use Saloon\Traits\Bootable;
 use Saloon\Traits\Makeable;
@@ -43,6 +44,10 @@ abstract class Request
      */
     public function getMethod(): Method
     {
+        if (! isset($this->method)) {
+            throw new LogicException('Your request is missing a HTTP method. You must add a method property like [protected Method $method = Method::GET]');
+        }
+
         return $this->method;
     }
 

--- a/tests/Fixtures/Requests/MissingMethodRequest.php
+++ b/tests/Fixtures/Requests/MissingMethodRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+class MissingMethodRequest extends Request
+{
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return '/user';
+    }
+}

--- a/tests/Fixtures/Requests/MissingMethodRequest.php
+++ b/tests/Fixtures/Requests/MissingMethodRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Saloon\Tests\Fixtures\Requests;
 
-use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
 class MissingMethodRequest extends Request

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
-use Saloon\Tests\Fixtures\Requests\MissingMethodRequest;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Responses\UserResponse;
 use Saloon\Exceptions\NoMockResponseFoundException;
@@ -12,6 +11,7 @@ use Saloon\Tests\Fixtures\Connectors\TestConnector;
 use Saloon\Tests\Fixtures\Responses\CustomResponse;
 use Saloon\Exceptions\InvalidResponseClassException;
 use Saloon\Tests\Fixtures\Requests\InvalidResponseClass;
+use Saloon\Tests\Fixtures\Requests\MissingMethodRequest;
 use Saloon\Tests\Fixtures\Requests\CustomEndpointRequest;
 use Saloon\Tests\Fixtures\Requests\DefaultEndpointRequest;
 use Saloon\Tests\Fixtures\Connectors\CustomBaseUrlConnector;

--- a/tests/Unit/RequestTest.php
+++ b/tests/Unit/RequestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Tests\Fixtures\Requests\MissingMethodRequest;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Responses\UserResponse;
 use Saloon\Exceptions\NoMockResponseFoundException;
@@ -117,3 +118,10 @@ test('you can join various URLs together', function ($baseUrl, $endpoint, $expec
     ['', 'google.com/search', '/google.com/search'],
     ['https://google.com', 'https://api.google.com/search', 'https://api.google.com/search'],
 ]);
+
+test('it throws an exception if you forget to add a method', function () {
+    $connector = new TestConnector;
+    $request = new MissingMethodRequest;
+
+    $connector->send($request);
+})->throws(LogicException::class, 'Your request is missing a HTTP method. You must add a method property like [protected Method $method = Method::GET]');


### PR DESCRIPTION
This PR improves the default error message if you forget to add a HTTP method to your request.

It will now say: `Your request is missing a HTTP method. You must add a method property like [protected Method $method = Method::GET]`