### PR TITLE
Remove Redundant Trait

### DIFF
--- a/src/Http/Connector.php
+++ b/src/Http/Connector.php
@@ -13,7 +13,6 @@ use Saloon\Traits\HandlesPsrRequest;
 use Saloon\Traits\ManagesExceptions;
 use Saloon\Traits\Connector\SendsRequests;
 use Saloon\Traits\Auth\AuthenticatesRequests;
-use Saloon\Traits\RequestProperties\HasDelay;
 use Saloon\Traits\RequestProperties\HasTries;
 use Saloon\Traits\Responses\HasCustomResponses;
 use Saloon\Traits\Request\CreatesDtoFromResponse;
@@ -32,7 +31,6 @@ abstract class Connector
     use Conditionable;
     use Bootable;
     use Makeable;
-    use HasDelay;
     use HasTries;
     use HasDebugging;
 


### PR DESCRIPTION
Removes the `HasDelay` trait definition on the abstract class `Connector`, which is already provided by the `HasRequestProperties` trait that is in use on this class, making the definition redundant, so it can be safely removed.

As below:
```php
trait HasRequestProperties
{
    use HasHeaders;
    use HasQuery;
    use HasConfig;
    use HasMiddleware;
    use HasDelay;
}
```