### PR TITLE
Fix | Remove Unnecesary @ throws tags in docblocks

### DIFF
--- a/src/Contracts/FakeResponse.php
+++ b/src/Contracts/FakeResponse.php
@@ -44,8 +44,6 @@ interface FakeResponse
 
     /**
      * Create a new mock response from a fixture
-     *
-     * @throws \Saloon\Exceptions\DirectoryNotFoundException
      */
     public static function fixture(string $name): Fixture;
 

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -66,7 +66,6 @@ final class Helpers
      * Check if a class is a subclass of another.
      *
      * @param class-string $class
-     * @throws \ReflectionException
      */
     public static function isSubclassOf(string $class, string $subclass): bool
     {

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -35,7 +35,6 @@ class MiddlewarePipeline
      *
      * @param callable(\Saloon\Http\PendingRequest): (\Saloon\Http\PendingRequest|\Saloon\Contracts\FakeResponse|void) $callable
      * @return $this
-     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
     public function onRequest(callable $callable, ?string $name = null, ?PipeOrder $order = null): static
     {
@@ -71,7 +70,6 @@ class MiddlewarePipeline
      *
      * @param callable(\Saloon\Http\Response): (\Saloon\Http\Response|void) $callable
      * @return $this
-     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
     public function onResponse(callable $callable, ?string $name = null, ?PipeOrder $order = null): static
     {
@@ -114,7 +112,6 @@ class MiddlewarePipeline
      * Merge in another middleware pipeline.
      *
      * @return $this
-     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
     public function merge(MiddlewarePipeline $middlewarePipeline): static
     {

--- a/src/Helpers/Pipeline.php
+++ b/src/Helpers/Pipeline.php
@@ -22,7 +22,6 @@ class Pipeline
      *
      * @param callable(mixed $payload): (mixed) $callable
      * @return $this
-     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
     public function pipe(callable $callable, ?string $name = null, ?PipeOrder $order = null): static
     {
@@ -79,7 +78,6 @@ class Pipeline
      *
      * @param array<\Saloon\Data\Pipe> $pipes
      * @return $this
-     * @throws \Saloon\Exceptions\DuplicatePipeNameException
      */
     public function setPipes(array $pipes): static
     {

--- a/src/Http/Faking/FakeResponse.php
+++ b/src/Http/Faking/FakeResponse.php
@@ -110,9 +110,6 @@ class FakeResponse implements FakeResponseContract
 
     /**
      * Create a new mock response from a fixture
-     *
-     * @throws \Saloon\Exceptions\DirectoryNotFoundException
-     * @throws \Saloon\Exceptions\UnableToCreateDirectoryException
      */
     public static function fixture(string $name): Fixture
     {

--- a/src/Http/Faking/Fixture.php
+++ b/src/Http/Faking/Fixture.php
@@ -30,9 +30,6 @@ class Fixture
 
     /**
      * Constructor
-     *
-     * @throws \Saloon\Exceptions\DirectoryNotFoundException
-     * @throws \Saloon\Exceptions\UnableToCreateDirectoryException
      */
     public function __construct(string $name = '', Storage $storage = null)
     {
@@ -42,9 +39,6 @@ class Fixture
 
     /**
      * Attempt to get the mock response from the fixture.
-     *
-     * @throws \Saloon\Exceptions\FixtureMissingException
-     * @throws \JsonException|\Saloon\Exceptions\FixtureException
      */
     public function getMockResponse(): ?MockResponse
     {
@@ -66,9 +60,6 @@ class Fixture
      * Store data as the fixture.
      *
      * @return $this
-     * @throws \JsonException
-     * @throws \Saloon\Exceptions\UnableToCreateDirectoryException
-     * @throws \Saloon\Exceptions\UnableToCreateFileException|\Saloon\Exceptions\FixtureException
      */
     public function store(RecordedResponse $recordedResponse): static
     {

--- a/src/Http/Middleware/DetermineMockResponse.php
+++ b/src/Http/Middleware/DetermineMockResponse.php
@@ -15,9 +15,6 @@ class DetermineMockResponse implements RequestMiddleware
     /**
      * Check if a MockClient has been provided and guess the MockResponse based on the request.
      *
-     * @throws \JsonException
-     * @throws \Saloon\Exceptions\DuplicatePipeNameException
-     * @throws \Saloon\Exceptions\FixtureException
      * @throws \Saloon\Exceptions\FixtureMissingException
      * @throws \Saloon\Exceptions\NoMockResponseFoundException
      */

--- a/src/Http/Middleware/RecordFixture.php
+++ b/src/Http/Middleware/RecordFixture.php
@@ -33,11 +33,6 @@ class RecordFixture implements ResponseMiddleware
 
     /**
      * Store the response
-     *
-     * @throws \JsonException
-     * @throws \Saloon\Exceptions\FixtureException
-     * @throws \Saloon\Exceptions\UnableToCreateDirectoryException
-     * @throws \Saloon\Exceptions\UnableToCreateFileException
      */
     public function __invoke(Response $response): void
     {

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -283,7 +283,6 @@ class PendingRequest
      * Get the response class
      *
      * @return class-string<\Saloon\Http\Response>
-     * @throws \ReflectionException
      * @throws \Saloon\Exceptions\InvalidResponseClassException
      */
     public function getResponseClass(): string

--- a/src/Http/Pool.php
+++ b/src/Http/Pool.php
@@ -142,8 +142,6 @@ class Pool
 
     /**
      * Send the pool and create a Promise
-     *
-     * @throws \Saloon\Exceptions\InvalidPoolItemException
      */
     public function send(): PromiseInterface
     {

--- a/src/Traits/Body/HasMultipartBody.php
+++ b/src/Traits/Body/HasMultipartBody.php
@@ -18,8 +18,6 @@ trait HasMultipartBody
 
     /**
      * Boot the HasMultipartBody trait
-     *
-     * @throws \Exception
      */
     public function bootHasMultipartBody(PendingRequest $pendingRequest): void
     {
@@ -28,8 +26,6 @@ trait HasMultipartBody
 
     /**
      * Retrieve the data repository
-     *
-     * @throws \Exception
      */
     public function body(): MultipartBodyRepository
     {

--- a/src/Traits/Macroable.php
+++ b/src/Traits/Macroable.php
@@ -35,7 +35,6 @@ trait Macroable
      * Add a mixin
      *
      * @param object|class-string $mixin
-     * @throws \ReflectionException
      */
     public static function mixin(object|string $mixin): void
     {

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -32,7 +32,6 @@ trait AuthorizationCodeGrant
      * Get the Authorization URL.
      *
      * @param array<string> $scopes
-     * @throws \Saloon\Exceptions\OAuthConfigValidationException
      */
     public function getAuthorizationUrl(array $scopes = [], string $state = null, string $scopeSeparator = ' ', array $additionalQueryParameters = []): string
     {
@@ -71,10 +70,7 @@ trait AuthorizationCodeGrant
      * @template TRequest of \Saloon\Http\Request
      *
      * @param callable(TRequest): (void)|null $requestModifier
-     * @throws \ReflectionException
      * @throws \Saloon\Exceptions\InvalidStateException
-     * @throws \Saloon\Exceptions\OAuthConfigValidationException
-     * @throws \Throwable
      */
     public function getAccessToken(string $code, string $state = null, string $expectedState = null, bool $returnResponse = false, ?callable $requestModifier = null): OAuthAuthenticator|Response
     {
@@ -109,9 +105,6 @@ trait AuthorizationCodeGrant
      * @template TRequest of \Saloon\Http\Request
      *
      * @param callable(TRequest): (void)|null $requestModifier
-     * @throws \ReflectionException
-     * @throws \Saloon\Exceptions\OAuthConfigValidationException
-     * @throws \Throwable
      */
     public function refreshAccessToken(OAuthAuthenticator|string $refreshToken, bool $returnResponse = false, ?callable $requestModifier = null): OAuthAuthenticator|Response
     {
@@ -179,8 +172,6 @@ trait AuthorizationCodeGrant
      * @template TRequest of \Saloon\Http\Request
      *
      * @param callable(TRequest): (void)|null $requestModifier
-     * @throws \ReflectionException
-     * @throws \Throwable
      */
     public function getUser(OAuthAuthenticator $oauthAuthenticator, ?callable $requestModifier = null): Response
     {

--- a/src/Traits/OAuth2/ClientCredentialsGrant.php
+++ b/src/Traits/OAuth2/ClientCredentialsGrant.php
@@ -24,9 +24,6 @@ trait ClientCredentialsGrant
      *
      * @param array<string> $scopes
      * @param callable(TRequest): (void)|null $requestModifier
-     * @throws \ReflectionException
-     * @throws \Saloon\Exceptions\OAuthConfigValidationException
-     * @throws \Throwable
      */
     public function getAccessToken(array $scopes = [], string $scopeSeparator = ' ', bool $returnResponse = false, ?callable $requestModifier = null): OAuthAuthenticator|Response
     {


### PR DESCRIPTION
This PR cleans up the usages of `@throws` tags inside of PHP docblocks. I have removed the ones which I didn't think were necessary for the end user to try/catch.