### PR TITLE
Fix | Allow createOAuthAuthenticator method to have a nullable refresh token

### DIFF
--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -161,7 +161,7 @@ trait AuthorizationCodeGrant
     /**
      * Create the authenticator.
      */
-    protected function createOAuthAuthenticator(string $accessToken, string $refreshToken, ?DateTimeImmutable $expiresAt = null): OAuthAuthenticator
+    protected function createOAuthAuthenticator(string $accessToken, ?string $refreshToken = null, ?DateTimeImmutable $expiresAt = null): OAuthAuthenticator
     {
         return new AccessTokenAuthenticator($accessToken, $refreshToken, $expiresAt);
     }

--- a/tests/Fixtures/Connectors/CustomResponseOAuth2Connector.php
+++ b/tests/Fixtures/Connectors/CustomResponseOAuth2Connector.php
@@ -15,7 +15,7 @@ class CustomResponseOAuth2Connector extends Connector
 {
     use AuthorizationCodeGrant;
 
-    
+
     public function __construct(protected string $greeting)
     {
         //
@@ -41,9 +41,9 @@ class CustomResponseOAuth2Connector extends Connector
     }
 
     /**
-     * Define a custom OAuth2 authenticator.
+     * Create the OAuth authenticator
      */
-    protected function createOAuthAuthenticator(string $accessToken, string $refreshToken, DateTimeImmutable $expiresAt): OAuthAuthenticator
+    protected function createOAuthAuthenticator(string $accessToken, ?string $refreshToken = null, ?DateTimeImmutable $expiresAt = null): OAuthAuthenticator
     {
         return new CustomOAuthAuthenticator($accessToken, $this->greeting,  $refreshToken, $expiresAt);
     }


### PR DESCRIPTION
Fixes #352