### PR TITLE
Feature | V3 Added a request option to assertSentCount

### DIFF
--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -180,9 +180,6 @@ test('can assert count of requests', function () {
 
     $mockClient->assertSentCount(3, UserRequest::class);
     $mockClient->assertSentCount(1, ErrorRequest::class);
-
-    $mockClient->assertSent(UserRequest::class, 3);
-    $mockClient->assertSent(ErrorRequest::class, 1);
 });
 
 test('assertSent with a closure works with more than one request in the history', function () {

--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -163,6 +163,28 @@ test('assertSentCount works properly', function () {
     $mockClient->assertSentCount(3);
 });
 
+test('can assert count of requests', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam']),
+        MockResponse::make(['name' => 'Taylor']),
+        MockResponse::make(['name' => 'Marcel']),
+        MockResponse::make(['message' => 'Error'], 500),
+    ]);
+
+    $connector = new TestConnector;
+
+    $connector->send(new UserRequest, $mockClient);
+    $connector->send(new UserRequest, $mockClient);
+    $connector->send(new UserRequest, $mockClient);
+    $connector->send(new ErrorRequest, $mockClient);
+
+    $mockClient->assertSentCount(3, UserRequest::class);
+    $mockClient->assertSentCount(1, ErrorRequest::class);
+
+    $mockClient->assertSent(UserRequest::class, 3);
+    $mockClient->assertSent(ErrorRequest::class, 1);
+});
+
 test('assertSent with a closure works with more than one request in the history', function () {
     $mockClient = new MockClient([
         MockResponse::make(['name' => 'Sam']),


### PR DESCRIPTION
This PR also deprecates the `assertSentJson` method because it was poorly implemented.