### PR TITLE
Feature | Deprecate Auth Methods

### DIFF
--- a/src/Traits/Auth/AuthenticatesRequests.php
+++ b/src/Traits/Auth/AuthenticatesRequests.php
@@ -83,7 +83,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with a query parameter token.
      *
-     * This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new QueryAuthenticator)` instead.
+     * @deprecated This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new QueryAuthenticator)` instead.
      * @return $this
      */
     public function withQueryAuth(string $parameter, string $value): static
@@ -94,7 +94,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with a header.
      *
-     * This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new HeaderAuthenticator)` instead.
+     * @deprecated This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new HeaderAuthenticator)` instead.
      * @return $this
      */
     public function withHeaderAuth(string $accessToken, string $headerName = 'Authorization'): static
@@ -105,7 +105,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with a certificate.
      *
-     * This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new CertificateAuthenticator)` instead.
+     * @deprecated This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new CertificateAuthenticator)` instead.
      * @return $this
      */
     public function withCertificateAuth(string $path, ?string $password = null): static

--- a/src/Traits/Auth/AuthenticatesRequests.php
+++ b/src/Traits/Auth/AuthenticatesRequests.php
@@ -50,6 +50,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with an Authorization header.
      *
+     * @deprecated This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new TokenAuthenticator)` instead.
      * @return $this
      */
     public function withTokenAuth(string $token, string $prefix = 'Bearer'): static
@@ -60,6 +61,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with "basic" authentication.
      *
+     * @deprecated This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new BasicAuthenticator)` instead.
      * @return $this
      */
     public function withBasicAuth(string $username, string $password): static
@@ -70,6 +72,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with "digest" authentication.
      *
+     * @deprecated This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new DigestAuthenticator)` instead.
      * @return $this
      */
     public function withDigestAuth(string $username, string $password, string $digest): static
@@ -80,6 +83,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with a query parameter token.
      *
+     * This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new QueryAuthenticator)` instead.
      * @return $this
      */
     public function withQueryAuth(string $parameter, string $value): static
@@ -90,6 +94,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with a header.
      *
+     * This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new HeaderAuthenticator)` instead.
      * @return $this
      */
     public function withHeaderAuth(string $accessToken, string $headerName = 'Authorization'): static
@@ -100,6 +105,7 @@ trait AuthenticatesRequests
     /**
      * Authenticate the request with a certificate.
      *
+     * This method will be removed in Saloon v4. You should use the defaultAuth method or the `->authenticate(new CertificateAuthenticator)` instead.
      * @return $this
      */
     public function withCertificateAuth(string $path, ?string $password = null): static

--- a/tests/Fixtures/Plugins/AuthenticatorPlugin.php
+++ b/tests/Fixtures/Plugins/AuthenticatorPlugin.php
@@ -8,7 +8,6 @@ use Saloon\Http\PendingRequest;
 
 trait AuthenticatorPlugin
 {
-    
     public function bootAuthenticatorPlugin(PendingRequest $pendingRequest): void
     {
         $pendingRequest->withTokenAuth('plugin-auth');


### PR DESCRIPTION
This PR deprecates the following methods on the connector/request
- `withTokenAuth`
- `withBasicAuth`
- `withDigestAuth`
- `withQueryAuth`
- `withHeaderAuth`
- `withCertificateAuth`

I would like to deprecate these methods as they were originally introduced into v1 as a convenient helper method to quickly add auth to an existing connector or request, but I feel that it goes against Saloon’s re-usability pattern. 

In my opinion, authentication should always be defined in the defaultAuth method of the connector or request however this auth can still be applied using the authenticate method. 