### PR TITLE
Feature | Deprecate Send And Retry Method

### DIFF
--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -154,6 +154,8 @@ trait SendsRequests
     /**
      * Send a synchronous request and retry if it fails
      *
+     * @deprecated This method will be removed in Saloon v4. Please refer to the documentation to see connector or request-based retry functionality.
+     *
      * @param callable(\Throwable, \Saloon\Http\Request): (bool)|null $handleRetry
      */
     public function sendAndRetry(Request $request, int $tries, int $interval = 0, callable $handleRetry = null, bool $throw = true, MockClient $mockClient = null, bool $useExponentialBackoff = false): Response


### PR DESCRIPTION
This PR deprecates the old `sendAndRetry` method in Saloon as it goes against Saloon's class-based pattern. You are still able to define retry functionality but you can now do this from within the connector or request class by using the `$tries` property.