### PR TITLE
Feature | Add HasEndpointPlaceholders trait for Request endpoints syntax sugar

### DIFF
--- a/src/Helpers/StringHelpers.php
+++ b/src/Helpers/StringHelpers.php
@@ -76,4 +76,20 @@ final class StringHelpers
 
         return $string;
     }
+
+    /**
+     * Replace one or multiple placeholders in curly braces with the given replacements.
+     *
+     * @param  array<string, mixed>  $replacements
+     */
+    public static function replacePlaceholders(string $value, array $replacements): string
+    {
+        return preg_match('/{.*}/', $value)
+            ? str_replace(
+                array_map(fn ($key) => '{'.$key.'}', array_keys($replacements)),
+                array_values($replacements),
+                $value
+            )
+            : $value;
+    }
 }

--- a/src/Traits/Request/HasEndpointPlaceholders.php
+++ b/src/Traits/Request/HasEndpointPlaceholders.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Traits\Request;
+
+use BackedEnum;
+use LogicException;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionUnionType;
+use Saloon\Helpers\StringHelpers;
+use Saloon\Http\Request;
+
+/** @mixin Request */
+trait HasEndpointPlaceholders
+{
+    /**
+     * Whenever you use this trait, you need to define the $endpoint property, e.g.:
+     * protected string $endpoint = '/foo/{id}';
+     */
+    protected function getEndpointAttribute(): string
+    {
+        return $this->endpoint ?? throw new LogicException(
+            'Your request class is missing an endpoint. Please add a property like [protected string $endpoint = \'/foo/{id}\'].'
+        );
+    }
+
+    /**
+     * Resolve endpoint with replacements.
+     */
+    public function resolveEndpoint(): string
+    {
+        return rtrim(StringHelpers::replacePlaceholders(
+            $this->getEndpointAttribute(),
+            $this->extractEndpointReplacements()
+        ), '/');
+    }
+
+    /**
+     * Using reflection to extract replacements from the constructor parameters (int|string|enum types only).
+     */
+    protected function extractEndpointReplacements(): array
+    {
+        $replacements = [];
+        $params = (new ReflectionClass($this))->getConstructor()?->getParameters() ?? [];
+
+        foreach ($params as $param) {
+            $type = $param->getType();
+            $name = $param->getName();
+
+            if ($type instanceof ReflectionNamedType) {
+                $typeName = $type->getName();
+            } elseif ($type instanceof ReflectionUnionType) {
+                // Cannot use $type->getName() as it's not a named type,
+                // and looping over $type->getTypes() does not help here.
+                $typeName = is_object($this->$name)
+                    ? get_class($this->$name)
+                    : get_debug_type($this->$name);
+            } else {
+                // Ignore parameters without a type
+                continue;
+            }
+
+            if (enum_exists($typeName)) {
+                // WARNING: $this->$name could be instanceof BackedEnum but be null on optional param
+                $replacements[$name] = $this->$name instanceof BackedEnum
+                    ? $this->$name?->value // Use the enum value if it's a BackedEnum
+                    : $this->$name?->name; // Use the enum name if it's a Basic enum
+            } elseif ($typeName === 'bool') {
+                // Replace boolean parameters with their name if true, or an empty string if false
+                $replacements[$name] = $this->$name ? $name : '';
+            } elseif (in_array($typeName, ['int', 'string'])) {
+                // Replace int|string parameters with their value
+                $replacements[$name] = $this->$name;
+            }
+        }
+
+        return $replacements;
+    }
+}

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Tests\Fixtures\Requests\HasEndpointPlaceholdersRequest;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
@@ -57,3 +58,15 @@ test('a request with HasConnector can be sent individually', function () {
         'twitter' => '@carre_sam',
     ]);
 });
+
+test('a request with HasEndpointPlaceholders resolves endpoint properly', function (
+    string $user, ?int $id, bool $purge, string $expected
+) {
+    $request = new HasEndpointPlaceholdersRequest($user, $id, $purge);
+
+    expect($request->resolveEndpoint())->toEqual($expected);
+})->with([
+    'with-bool' => ['Sammyjo20', 123, true, '/Sammyjo20/post/123/purge'],
+    'trimmed-bool' => ['Sammyjo20', 123, false, '/Sammyjo20/post/123'],
+    'trimmed-null' => ['Sammyjo20', null, false, '/Sammyjo20/post'],
+]);

--- a/tests/Feature/RequestTest.php
+++ b/tests/Feature/RequestTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 use Saloon\Http\Response;
 use Saloon\Http\PendingRequest;
 use Saloon\Http\Senders\GuzzleSender;
+use Saloon\Tests\Fixtures\Enums\AnotherEnum;
+use Saloon\Tests\Fixtures\Enums\GenderEnum;
+use Saloon\Tests\Fixtures\Enums\SomeEnum;
 use Saloon\Tests\Fixtures\Requests\HasEndpointPlaceholdersRequest;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;
@@ -60,13 +63,14 @@ test('a request with HasConnector can be sent individually', function () {
 });
 
 test('a request with HasEndpointPlaceholders resolves endpoint properly', function (
-    string $user, ?int $id, bool $purge, string $expected
+    string $user, GenderEnum $gender, SomeEnum|AnotherEnum $something, ?int $id, bool $purge, string $expected
 ) {
-    $request = new HasEndpointPlaceholdersRequest($user, $id, $purge);
+    $request = new HasEndpointPlaceholdersRequest($user, $gender, $something, $id, $purge);
 
     expect($request->resolveEndpoint())->toEqual($expected);
 })->with([
-    'with-bool' => ['Sammyjo20', 123, true, '/Sammyjo20/post/123/purge'],
-    'trimmed-bool' => ['Sammyjo20', 123, false, '/Sammyjo20/post/123'],
-    'trimmed-null' => ['Sammyjo20', null, false, '/Sammyjo20/post'],
+    'with-bool' => ['Sammyjo20', GenderEnum::MALE, SomeEnum::FOO, 123, true, '/Sammyjo20/male/foo/post/123/purge'],
+    'trimmed-bool' => ['Sammyjo20', GenderEnum::MALE, SomeEnum::FOO, 123, false, '/Sammyjo20/male/foo/post/123'],
+    'trimmed-null' => ['Sammyjo20', GenderEnum::MALE, SomeEnum::FOO, null, false, '/Sammyjo20/male/foo/post'],
+    'union-enum' => ['Sammyjo20', GenderEnum::MALE, AnotherEnum::ALL, 456, false, '/Sammyjo20/male/all/post/456'],
 ]);

--- a/tests/Fixtures/Enums/AnotherEnum.php
+++ b/tests/Fixtures/Enums/AnotherEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Enums;
+
+enum AnotherEnum: string
+{
+    case SOME = 'some';
+    case ALL = 'all';
+}

--- a/tests/Fixtures/Enums/GenderEnum.php
+++ b/tests/Fixtures/Enums/GenderEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Enums;
+
+enum GenderEnum: string
+{
+    case FEMALE = 'female';
+    case MALE = 'male';
+    case NONBINARY = 'nonbinary';
+}

--- a/tests/Fixtures/Enums/SomeEnum.php
+++ b/tests/Fixtures/Enums/SomeEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Enums;
+
+enum SomeEnum: string
+{
+    case FOO = 'foo';
+    case BAR = 'bar';
+    case BAZ = 'baz';
+}

--- a/tests/Fixtures/Requests/HasEndpointPlaceholdersRequest.php
+++ b/tests/Fixtures/Requests/HasEndpointPlaceholdersRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Traits\Request\HasEndpointPlaceholders;
+
+class HasEndpointPlaceholdersRequest extends Request
+{
+    use HasEndpointPlaceholders;
+
+    /**
+     * Define endpoint
+     */
+    protected string $endpoint = '/{user}/post/{id}/{purge}';
+
+    /**
+     * Define the HTTP method.
+     *
+     * @var Method
+     */
+    protected Method $method = Method::DELETE;
+
+    public function __construct(
+        protected string $user,
+        protected ?int $id = null,
+        protected bool $purge = false,
+    ) {
+    }
+}

--- a/tests/Fixtures/Requests/HasEndpointPlaceholdersRequest.php
+++ b/tests/Fixtures/Requests/HasEndpointPlaceholdersRequest.php
@@ -6,6 +6,9 @@ namespace Saloon\Tests\Fixtures\Requests;
 
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
+use Saloon\Tests\Fixtures\Enums\AnotherEnum;
+use Saloon\Tests\Fixtures\Enums\GenderEnum;
+use Saloon\Tests\Fixtures\Enums\SomeEnum;
 use Saloon\Traits\Request\HasEndpointPlaceholders;
 
 class HasEndpointPlaceholdersRequest extends Request
@@ -15,7 +18,7 @@ class HasEndpointPlaceholdersRequest extends Request
     /**
      * Define endpoint
      */
-    protected string $endpoint = '/{user}/post/{id}/{purge}';
+    protected string $endpoint = '/{user}/{gender}/{something}/post/{id}/{purge}';
 
     /**
      * Define the HTTP method.
@@ -26,6 +29,8 @@ class HasEndpointPlaceholdersRequest extends Request
 
     public function __construct(
         protected string $user,
+        protected GenderEnum $gender,
+        protected SomeEnum|AnotherEnum $something,
         protected ?int $id = null,
         protected bool $purge = false,
     ) {


### PR DESCRIPTION
This adds a new `HasEndpointPlaceholders` trait which can be (optionally) used on any Saloon Request as syntax sugar. So instead of overriding `resolveEndpoint()` like so:

```php
class GetUser extends Request
{
    protected Method $method = Method::GET;

    public function __construct(protected int $id) {}

    public function resolveEndpoint(): string
    {
        return "/user/{$this->id}";
    }
```

... you could use:

```php
class GetUser extends Request
{
    use HasEndpointPlaceholders;

    protected Method $method = Method::GET;

    protected string $endpoint = '/user/{id}';

    public function __construct(protected int $id) {}
```

This especially makes sense when you use some custom `AbstractRequest` that extends from `Saloon\Http\Request`, so you would only need to `use HasEndpointPlaceholders` once. It also makes sense if you have a lot of different constructor params – the `HasEndpointPlaceholders` will pick the ones found in your `$endpoint` template by reflection, supporting `int`, `string`, `bool`, or `enum` types.

I use this in like 80% of my integrations/requests and it saved me tons of lines, also greatly increased readability.

Cheers,
Pipo