### PR TITLE
Proposal: Generic types for DTO casting

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -287,8 +287,11 @@ class Response
 
     /**
      * Cast the response to a DTO.
+     *
+     * @template T of object
+     * @return ($dto is class-string<T> ? T : object)
      */
-    public function dto(): mixed
+    public function dto(?string $dto = null): mixed
     {
         $request = $this->pendingRequest->getRequest();
         $connector = $this->pendingRequest->getConnector();
@@ -304,8 +307,11 @@ class Response
 
     /**
      * Convert the response into a DTO or throw a LogicException if the response failed
+     *
+     * @template T of object
+     * @return ($dto is class-string<T> ? T : object)
      */
-    public function dtoOrFail(): mixed
+    public function dtoOrFail(?string $dto = null): mixed
     {
         if ($this->failed()) {
             throw new LogicException('Unable to create data transfer object as the response has failed.', 0, $this->toException());

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -76,7 +76,7 @@ class Response
     /**
      * Create a new response instance.
      */
-    public function __construct(ResponseInterface $psrResponse, PendingRequest $pendingRequest, RequestInterface $psrRequest, Throwable $senderException = null)
+    public function __construct(ResponseInterface $psrResponse, PendingRequest $pendingRequest, RequestInterface $psrRequest, ?Throwable $senderException = null)
     {
         $this->psrRequest = $psrRequest;
         $this->psrResponse = $psrResponse;
@@ -193,7 +193,7 @@ class Response
     /**
      * Get the JSON decoded body of the response as an array or scalar value.
      *
-     * @param array-key|null $key
+     * @param  array-key|null  $key
      * @return ($key is null ? array<array-key, mixed> : mixed)
      */
     public function json(string|int|null $key = null, mixed $default = null): mixed
@@ -214,7 +214,7 @@ class Response
      *
      * Alias of json()
      *
-     * @param array-key|null $key
+     * @param  array-key|null  $key
      * @return ($key is null ? array<array-key, mixed> : mixed)
      */
     public function array(int|string|null $key = null, mixed $default = null): mixed
@@ -265,9 +265,10 @@ class Response
      * Get the JSON decoded body of the response as a collection.
      *
      * Requires Laravel Collections (composer require illuminate/collections)
+     *
      * @see https://github.com/illuminate/collections
      *
-     * @param array-key|null $key
+     * @param  array-key|null  $key
      * @return \Illuminate\Support\Collection<array-key, mixed>
      */
     public function collect(string|int|null $key = null): Collection
@@ -289,6 +290,7 @@ class Response
      * Cast the response to a DTO.
      *
      * @template T of object
+     *
      * @return ($dto is class-string<T> ? T : object)
      */
     public function dto(?string $dto = null): mixed
@@ -309,6 +311,7 @@ class Response
      * Convert the response into a DTO or throw a LogicException if the response failed
      *
      * @template T of object
+     *
      * @return ($dto is class-string<T> ? T : object)
      */
     public function dtoOrFail(?string $dto = null): mixed
@@ -400,7 +403,7 @@ class Response
     /**
      * Execute the given callback if there was a server or client error.
      *
-     * @param callable($this): (void) $callback
+     * @param  callable($this): (void)  $callback
      * @return $this
      */
     public function onError(callable $callback): static
@@ -460,6 +463,7 @@ class Response
      * Throw an exception if a server or client error occurred.
      *
      * @return $this
+     *
      * @throws \Throwable
      */
     public function throw(): static
@@ -504,7 +508,7 @@ class Response
     /**
      * Save the body to a file
      *
-     * @param string|resource $resourceOrPath
+     * @param  string|resource  $resourceOrPath
      */
     public function saveBodyToFile(mixed $resourceOrPath, bool $closeResource = true): void
     {

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -320,7 +320,7 @@ class Response
             throw new LogicException('Unable to create data transfer object as the response has failed.', 0, $this->toException());
         }
 
-        return $this->dto();
+        return $this->dto($dto);
     }
 
     /**

--- a/tests/Feature/DataObjectWrapperTest.php
+++ b/tests/Feature/DataObjectWrapperTest.php
@@ -9,6 +9,7 @@ use Saloon\Contracts\DataObjects\WithResponse;
 use Saloon\Tests\Fixtures\Requests\DTORequest;
 use Saloon\Tests\Fixtures\Data\UserWithResponse;
 use Saloon\Tests\Fixtures\Requests\DTOWithResponseRequest;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
 
 test('if a dto does not implement the WithResponse interface and HasResponse trait Saloon will not add the original response', function () {
     $mockClient = new MockClient([
@@ -16,7 +17,8 @@ test('if a dto does not implement the WithResponse interface and HasResponse tra
     ]);
 
     $response = connector()->send(new DTORequest, $mockClient);
-    $dto = $response->dto();
+
+    $dto = $response->dto(User::class);
 
     expect($dto)->toBeInstanceOf(User::class);
     expect($dto)->not->toBeInstanceOf(WithResponse::class);
@@ -36,4 +38,29 @@ test('if a dto implements the WithResponse interface and HasResponse trait Saloo
     expect($dto)->toBeInstanceOf(UserWithResponse::class);
     expect($dto)->toBeInstanceOf(WithResponse::class);
     expect($dto->getResponse())->toBe($response);
+});
+
+test('if a dto type is provided and the class does not support a dto null is still returned', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sammyjo20', 'actual_name' => 'Sam', 'twitter' => '@carre_sam']),
+    ]);
+
+    $response = connector()->send(new UserRequest, $mockClient);
+
+    $dto = $response->dto(User::class);
+
+    expect($dto)->toBeNull();
+});
+
+test('if a dto type is provided and the class returned doesnt match an exception is thrown', function () {
+    $mockClient = new MockClient([
+        new MockResponse(['name' => 'Sammyjo20', 'actual_name' => 'Sam', 'twitter' => '@carre_sam']),
+    ]);
+
+    $response = connector()->send(new DTORequest, $mockClient);
+
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage('The class-string provided [Saloon\Tests\Fixtures\Data\UserWithResponse] must match the class-string returned by the connector/request [Saloon\Tests\Fixtures\Data\User].');
+
+    $response->dto(UserWithResponse::class);
 });

--- a/tests/Feature/DataObjectWrapperTest.php
+++ b/tests/Feature/DataObjectWrapperTest.php
@@ -7,9 +7,9 @@ use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Data\User;
 use Saloon\Contracts\DataObjects\WithResponse;
 use Saloon\Tests\Fixtures\Requests\DTORequest;
+use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Data\UserWithResponse;
 use Saloon\Tests\Fixtures\Requests\DTOWithResponseRequest;
-use Saloon\Tests\Fixtures\Requests\UserRequest;
 
 test('if a dto does not implement the WithResponse interface and HasResponse trait Saloon will not add the original response', function () {
     $mockClient = new MockClient([


### PR DESCRIPTION
I've added annotations for the `dto` and `dtoOrFail` methods, enabling passing of a `class-string` to each method, in order to get proper type suppose when working with the response.

The new `$dto` parameter is optional to enable backwards-compatibility, but means that you can call the method with a FQCN passed as an argument, in order to get type completion.

Omitting the argument continues as currently.

I was inspired by @ash-jc-allen's [blog post](https://ashallendesign.co.uk/blog/data-transfer-objects-dtos-in-php), which passed the `FQCN` to this method, which initially looked unnecessary to me.

```diff
public function getRepo(string $owner, string $repo): Repo
{
    return $this->client()
        ->send(new GetRepo($owner, $repo))
+       ->dtoOrFail(Repo::class);
}
```

This implementation conforms to PHPStan requirements, so I believe it to be _technically_ correct, but I wasn't actually able to verify it in my editor (Neovim).

For it to function (for me), I had to tweak the annotation slightly:

```diff
  * @template T of object
+ * @param class-string<T>|null $dto
- * @return ($dto of class-string<T> ? T : object)
+ * @return T
```