### PR TITLE
Fix | Getting Single Multipart Value

### DIFF
--- a/src/Repositories/Body/MultipartBodyRepository.php
+++ b/src/Repositories/Body/MultipartBodyRepository.php
@@ -127,9 +127,9 @@ class MultipartBodyRepository implements BodyRepository, MergeableBody
      */
     public function get(string|int $key, mixed $default = null): MultipartValue|array
     {
-        $values = array_filter($this->all(), static function (MultipartValue $value) use ($key) {
+        $values = array_values(array_filter($this->all(), static function (MultipartValue $value) use ($key) {
             return $value->name === $key;
-        });
+        }));
 
         if (count($values) === 0) {
             return $default;

--- a/tests/Unit/Body/MultipartBodyRepositoryTest.php
+++ b/tests/Unit/Body/MultipartBodyRepositoryTest.php
@@ -100,8 +100,10 @@ test('you can get an item', function () {
     $body = new MultipartBodyRepository();
 
     $body->add('name', 'Sam');
+    $body->add('friend', 'Chris');
 
     expect($body->get('name'))->toEqual(new MultipartValue('name', 'Sam'));
+    expect($body->get('friend'))->toEqual(new MultipartValue('friend', 'Chris'));
 });
 
 test('you can get multiple items with the same name', function () {


### PR DESCRIPTION
This PR fixes a small issue we were having when retrieving a value from the MultipartBodyRepository when the value is not the first item.