### PR TITLE
Feature | Add `assertSentInOrder` assertion to MockClient

### DIFF
--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -263,7 +263,6 @@ class MockClient
      * Assert that given requests were sent in order
      *
      * @param array<\Closure|class-string<Request>|string> $callbacks
-     * @return void
      */
     public function assertSentInOrder(array $callbacks): void
     {

--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -259,7 +259,12 @@ class MockClient
         PHPUnit::assertTrue($result, 'An unexpected request was sent.');
     }
 
-
+    /**
+     * Assert that given requests were sent in order
+     *
+     * @param array<\Closure|class-string<Request>|string> $callbacks
+     * @return void
+     */
     public function assertSentInOrder(array $callbacks): void
     {
         $this->assertSentCount(count($callbacks));
@@ -320,7 +325,6 @@ class MockClient
             return $this->checkClosureAgainstResponses($request, $index);
         }
 
-
         if (is_string($request)) {
             if (class_exists($request) && Helpers::isSubclassOf($request, Request::class)) {
                 $passed = $this->findResponseByRequest($request, $index) instanceof Response;
@@ -349,8 +353,9 @@ class MockClient
             return null;
         }
 
-        if($index) {
+        if(! is_null($index)) {
             $recordedResponse = $this->getRecordedResponses()[$index];
+
             if ($recordedResponse->getPendingRequest()->getRequest() instanceof $request) {
                 return $recordedResponse;
             }
@@ -380,7 +385,7 @@ class MockClient
             return null;
         }
 
-        if($index) {
+        if(! is_null($index)) {
             $response = $this->getRecordedResponses()[$index];
             $pendingRequest = $response->getPendingRequest();
 
@@ -447,7 +452,7 @@ class MockClient
             return false;
         }
 
-        if($index) {
+        if(! is_null($index)) {
             $response = $this->getRecordedResponses()[$index];
             $request = $response->getPendingRequest()->getRequest();
 

--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -244,8 +244,6 @@ test('it can assert requests are sent in a specific order failure', function () 
     $connector->send(new UserRequest(userId: 1), $mockClient);
     $connector->send(new UserRequest(), $mockClient);
 
-
-
     $mockClient->assertSentInOrder([
         UserRequest::class,
         function (UserRequest $request) {

--- a/tests/Unit/MockClientAssertionsTest.php
+++ b/tests/Unit/MockClientAssertionsTest.php
@@ -8,6 +8,7 @@ use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Requests\ErrorRequest;
+use PHPUnit\Framework\ExpectationFailedException;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
 
 test('assertSent works with a request', function () {
@@ -207,3 +208,49 @@ test('assertSent with a closure works with more than one request in the history'
         return $response->json() === ['name' => 'Marcel'] && $response->status() === 204;
     });
 });
+
+test('it can assert requests are sent in a specific order', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam']),
+        MockResponse::make(['name' => 'Taylor'], 201),
+        MockResponse::make(['name' => 'Marcel'], 204),
+    ]);
+
+    $connector = new TestConnector;
+
+    $connector->send(new UserRequest, $mockClient);
+    $connector->send(new UserRequest, $mockClient);
+    $connector->send(new UserRequest, $mockClient);
+
+    $mockClient->assertSentInOrder([
+        UserRequest::class,
+        function (UserRequest $request, Response $response) {
+            return $response->json() === ['name' => 'Taylor'];
+        },
+        '/user',
+    ]);
+});
+
+test('it can assert requests are sent in a specific order failure', function () {
+    $mockClient = new MockClient([
+        MockResponse::make(['name' => 'Sam']),
+        MockResponse::make(['name' => 'Taylor'], 201),
+        MockResponse::make(['name' => 'Marcel'], 204),
+    ]);
+
+    $connector = new TestConnector;
+
+    $connector->send(new UserRequest(userId: 2), $mockClient);
+    $connector->send(new UserRequest(userId: 1), $mockClient);
+    $connector->send(new UserRequest(), $mockClient);
+
+
+
+    $mockClient->assertSentInOrder([
+        UserRequest::class,
+        function (UserRequest $request) {
+            return $request->userId === 2;
+        },
+        '/user',
+    ]);
+})->expectException(ExpectationFailedException::class);


### PR DESCRIPTION
In Laravel there's quite a neat assertion on the Http client called `assertSentInOrder`, it kind of does what it says on the tin, it allows you to check that the requests that are made are sent in the same order as you expect them.

To me this opens up quite a few testing scenarios like this:
```php
$mockClient->assertSentInOrder([
            function (FirstRequest $request) {
                // some specific assertion on the first request + type info
                return true;
            },
            function (SecondRequest $request) {
                // some specific assertion on the second request + type info
                return true;
            },
        ])
```