### PR TITLE
Add client credentials grant with basic auth

### DIFF
--- a/src/Http/OAuth2/GetClientCredentialsTokenBasicAuthRequest.php
+++ b/src/Http/OAuth2/GetClientCredentialsTokenBasicAuthRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Http\OAuth2;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Contracts\Body\HasBody;
+use Saloon\Contracts\Authenticator;
+use Saloon\Traits\Body\HasFormBody;
+use Saloon\Helpers\OAuth2\OAuthConfig;
+use Saloon\Traits\Plugins\AcceptsJson;
+use Saloon\Http\Auth\BasicAuthenticator;
+
+class GetClientCredentialsTokenBasicAuthRequest extends Request implements HasBody
+{
+    use HasFormBody;
+    use AcceptsJson;
+
+    /**
+     * Define the method that the request will use.
+     */
+    protected Method $method = Method::POST;
+
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return $this->oauthConfig->getTokenEndpoint();
+    }
+
+    /**
+     * Requires the authorization code and OAuth 2 config.
+     *
+     * @param array<string> $scopes
+     */
+    public function __construct(protected OAuthConfig $oauthConfig, protected array $scopes = [], protected string $scopeSeparator = ' ')
+    {
+        //
+    }
+
+    /**
+     * Register the default data.
+     *
+     * @return array{
+     *     grant_type: string,
+     *     scope: string,
+     * }
+     */
+    public function defaultBody(): array
+    {
+        return [
+            'grant_type' => 'client_credentials',
+            'scope' => implode($this->scopeSeparator, array_merge($this->oauthConfig->getDefaultScopes(), $this->scopes)),
+        ];
+    }
+
+    /**
+     * Default authenticator used.
+     */
+    protected function defaultAuth(): ?Authenticator
+    {
+        return new BasicAuthenticator($this->oauthConfig->getClientId(), $this->oauthConfig->getClientSecret());
+    }
+}

--- a/src/Traits/OAuth2/ClientCredentialsBasicAuthGrant.php
+++ b/src/Traits/OAuth2/ClientCredentialsBasicAuthGrant.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Traits\OAuth2;
+
+use Saloon\Http\Request;
+use Saloon\Helpers\OAuth2\OAuthConfig;
+use Saloon\Http\OAuth2\GetClientCredentialsTokenBasicAuthRequest;
+
+trait ClientCredentialsBasicAuthGrant
+{
+    use ClientCredentialsGrant;
+
+    /**
+     * Resolve the access token request
+     */
+    protected function resolveAccessTokenRequest(OAuthConfig $oauthConfig, array $scopes = [], string $scopeSeparator = ' '): Request
+    {
+        return new GetClientCredentialsTokenBasicAuthRequest($oauthConfig, $scopes, $scopeSeparator);
+    }
+}

--- a/tests/Fixtures/Connectors/ClientCredentialsBasicAuthConnector.php
+++ b/tests/Fixtures/Connectors/ClientCredentialsBasicAuthConnector.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Connectors;
+
+use Saloon\Http\Connector;
+use Saloon\Helpers\OAuth2\OAuthConfig;
+use Saloon\Traits\OAuth2\ClientCredentialsBasicAuthGrant;
+
+class ClientCredentialsBasicAuthConnector extends Connector
+{
+    use ClientCredentialsBasicAuthGrant;
+
+    /**
+     * Define the base URL.
+     */
+    public function resolveBaseUrl(): string
+    {
+        return 'https://oauth.saloon.dev';
+    }
+
+    /**
+     * Define default Oauth config.
+     */
+    protected function defaultOauthConfig(): OAuthConfig
+    {
+        return OAuthConfig::make()
+            ->setClientId('client-id')
+            ->setClientSecret('client-secret');
+    }
+}


### PR DESCRIPTION
The currently supported OAuth2 client credentials grant includes the client_id and the client_secret in the body of the request. Some APIs require that the client_id and client_secret are sent using the HTTP Basic Authentication scheme. This PR adds a new client credentials request that supports the basic authentication method instead of the request body method.

The request only adds new files and should not cause any backwards compatibility issues.

RFC reference: https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1

Implementation Notes:
- The new `GetClientCredentialsTokenBasicAuthRequest` was copied from the existing `GetClientCredentialsTokenRequest`. The `defaultBody()` method was updated to remove the `client_id`/`client_secret` from the body, and the `defaultAuth()` method was added to implement the basic authentication.
- The new `ClientCredentialsBasicAuthGrant` trait uses the existing `ClientCredentialsGrant` trait, and just redefines the `resolveAccessTokenRequest()` method to use the new request file.
- A new test was added to ensure the request body and Authentication header are as expected.