### PR TITLE
Feature | Add a `NullAuthenticator` to overwrite defaultAuth

### DIFF
--- a/src/Http/Auth/NullAuthenticator.php
+++ b/src/Http/Auth/NullAuthenticator.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Http\Auth;
+
+use Saloon\Http\PendingRequest;
+use Saloon\Contracts\Authenticator;
+
+class NullAuthenticator implements Authenticator
+{
+    /**
+     * Apply the authentication to the request.
+     */
+    public function set(PendingRequest $pendingRequest): void
+    {
+        //
+    }
+}

--- a/tests/Unit/AuthenticatesRequestsTest.php
+++ b/tests/Unit/AuthenticatesRequestsTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 use GuzzleHttp\RequestOptions;
 use Saloon\Exceptions\SaloonException;
-use Saloon\Http\Auth\MultiAuthenticator;
 use Saloon\Http\Auth\NullAuthenticator;
+use Saloon\Http\Auth\MultiAuthenticator;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Auth\HeaderAuthenticator;
-use Saloon\Tests\Fixtures\Connectors\DefaultAuthenticatorConnector;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\ArraySenderConnector;
+use Saloon\Tests\Fixtures\Connectors\DefaultAuthenticatorConnector;
 
 test('you can add basic auth to a request', function () {
     $request = new UserRequest;

--- a/tests/Unit/AuthenticatesRequestsTest.php
+++ b/tests/Unit/AuthenticatesRequestsTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 use GuzzleHttp\RequestOptions;
 use Saloon\Exceptions\SaloonException;
 use Saloon\Http\Auth\MultiAuthenticator;
+use Saloon\Http\Auth\NullAuthenticator;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Auth\HeaderAuthenticator;
+use Saloon\Tests\Fixtures\Connectors\DefaultAuthenticatorConnector;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\ArraySenderConnector;
 
@@ -105,4 +107,15 @@ test('you can use multiple authenticators at the same time using the defaultAuth
         'Authorization' => 'Bearer example',
         'X-API-Key' => 'api-key',
     ]);
+});
+
+test('you can use a null authenticator to disable default authentication entirely', function () {
+    $connector = new DefaultAuthenticatorConnector;
+    $request = new UserRequest;
+
+    $request->authenticate(new NullAuthenticator);
+
+    $pendingRequest = $connector->createPendingRequest($request);
+
+    expect($pendingRequest->headers()->all())->toEqual(['Accept' => 'application/json']);
 });


### PR DESCRIPTION
This PR adds a `NullAuthenticator` class that allows a user to use the null object pattern, and provides a way to remove an authenticator that has already been set.

This has been addressed in #402 and [#385](https://github.com/saloonphp/saloon/issues/385#issuecomment-2125073941).

This PR only adds a new file, so it should not have any backwards compatibility issues.