### PR TITLE
Feature | Accept type-hinted requests as `assertSent` parameters

### DIFF
--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -54,3 +54,18 @@ parameters:
 		 message: "#^Match arm is unreachable because previous comparison is always true.$#"
 		 count: 1
 		 path: src/Http/Pool.php
+
+		-
+		 message: "#^Method Saloon\\\\Http\\\\Faking\\\\MockClient\\:\\:getRequestClass\\(\\) should return class-string|null but returns class-string<Saloon\\\\Http\\\\Request>|Saloon\\\\Http\\\\Request$#"
+		 count: 1
+		 path: src/Http/Faking/MockClient.php
+
+		-
+		 message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"
+		 count: 1
+		 path: src/Http/Faking/MockClient.php
+
+		-
+		 message: "#^Parameter \\#1 \\$function of class ReflectionFunction constructor expects Closure|string, callable\\(\\)\\: mixed given\\.$#"
+		 count: 1
+		 path: src/Http/Faking/MockClient.php

--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -451,14 +451,29 @@ class MockClient
             return false;
         }
 
-        if(! is_null($index)) {
+        if (! is_null($index)) {
             $response = $this->getRecordedResponses()[$index];
             $request = $response->getPendingRequest()->getRequest();
 
             return $closure($request, $response);
         }
 
-        // Let's first check if the latest response resolves the callable
+        // Let's first check if the callable type-hints the latest request class.
+        // If so, we try to find the corresponding request in the recorded responses
+        // and call the callable accordingly. We will only fail if it returns `false`.
+
+        if ($fqcn = $this->getRequestClass($closure)) {
+            /** @var Response */
+            foreach ($this->getRecordedResponses() as $response) {
+                if (get_class($request = $response->getPendingRequest()->getRequest()) !== $fqcn) {
+                    continue;
+                }
+
+                return $closure($request, $response) !== false;
+            }
+        }
+
+        // Let's then check if the latest response resolves the callable
         // with a successful result.
 
         $lastResponse = $this->getLastResponse();
@@ -523,5 +538,26 @@ class MockClient
         }, $this->getRecordedResponses());
 
         return array_count_values($requests);
+    }
+
+    /**
+     * Get the FQCN of the request class if type-hinted.
+     *
+     * @return class-string
+     */
+    private function getRequestClass(callable $closure): ?string
+    {
+        $reflection = new \ReflectionFunction($closure);
+        $parameters = $reflection->getParameters();
+
+        if (! ($fqcn = $parameters[0]->getType()?->getName())) {
+            return null;
+        }
+
+        if (! is_a($fqcn, Request::class, allow_string: true)) {
+            return null;
+        }
+
+        return $fqcn;
     }
 }


### PR DESCRIPTION
Closes https://github.com/saloonphp/saloon/issues/417

This pull request adds support for type-hinting a request class as the first parameter of the closure passed to `MockClient#assertSent`. This allows running this kind of test:

```php
MockClient::getGlobal()->assertSent(function (CreateDealRequest $request) {
    expect($request->body()->all())->toMatchArray([
        'status' => DealStatus::OPEN,
    ]);
});
```

Before this pull request, the test above could only be written using a condition:

```php
MockClient::getGlobal()->assertSent(function (Request $request) {
    if ($request instanceof CreateDealRequest) {
        expect($request->body()->all())->toMatchArray([
            'status' => DealStatus::OPEN,
        ]);

        return true;
    }
});
```