### PR TITLE
Add `Stringable` to OAuthConfig `set` methods.

### DIFF
--- a/src/Helpers/OAuth2/OAuthConfig.php
+++ b/src/Helpers/OAuth2/OAuthConfig.php
@@ -8,6 +8,7 @@ use Closure;
 use Saloon\Http\Request;
 use Saloon\Traits\Makeable;
 use Saloon\Exceptions\OAuthConfigValidationException;
+use Stringable;
 
 /**
  * @method static static make()
@@ -73,7 +74,7 @@ class OAuthConfig
      *
      * @return $this
      */
-    public function setClientId(string $clientId): static
+    public function setClientId(string|Stringable $clientId): static
     {
         $this->clientId = $clientId;
 
@@ -93,7 +94,7 @@ class OAuthConfig
      *
      * @return $this
      */
-    public function setClientSecret(string $clientSecret): static
+    public function setClientSecret(string|Stringable $clientSecret): static
     {
         $this->clientSecret = $clientSecret;
 
@@ -113,7 +114,7 @@ class OAuthConfig
      *
      * @return $this
      */
-    public function setRedirectUri(string $redirectUri): static
+    public function setRedirectUri(string|Stringable $redirectUri): static
     {
         $this->redirectUri = $redirectUri;
 
@@ -133,7 +134,7 @@ class OAuthConfig
      *
      * @return $this
      */
-    public function setAuthorizeEndpoint(string $authorizeEndpoint): static
+    public function setAuthorizeEndpoint(string|Stringable $authorizeEndpoint): static
     {
         $this->authorizeEndpoint = $authorizeEndpoint;
 
@@ -153,7 +154,7 @@ class OAuthConfig
      *
      * @return $this
      */
-    public function setTokenEndpoint(string $tokenEndpoint): static
+    public function setTokenEndpoint(string|Stringable $tokenEndpoint): static
     {
         $this->tokenEndpoint = $tokenEndpoint;
 
@@ -173,7 +174,7 @@ class OAuthConfig
      *
      * @return $this
      */
-    public function setUserEndpoint(string $userEndpoint): static
+    public function setUserEndpoint(string|Stringable $userEndpoint): static
     {
         $this->userEndpoint = $userEndpoint;
 


### PR DESCRIPTION
This PR adds `|Stringable` to the `set` methods in the OAuthConfig class that accept a string parameter.

In my use case, I'm constructing URLs using the [spatie/url](https://github.com/spatie/url) package and would like to be able to pass the URL directly to the `setAuthorizeEndpoint()` method:

```PHP
$this->oauthConfig()->setAuthorizeEndpoint(
    Url::fromString('https://api.example.com/oauth2/authorize')
    ->withQueryParameters([
        'app_key' => $appKey,
        'response_type' => 'code'
    ])
);
```

The `Url` implements the `Stringable` `__toString()` method so I can either cast to a string or update Saloon to support `Stringable` parameters :smile:
