### PR TITLE
Fix | Resolve headers with array as value

### DIFF
--- a/src/Helpers/FixtureHelper.php
+++ b/src/Helpers/FixtureHelper.php
@@ -24,7 +24,7 @@ class FixtureHelper
 
         array_walk_recursive($source, static function (&$value, $key) use ($rules, $caseSensitiveKeys) {
             if ($caseSensitiveKeys === false) {
-                $key = mb_strtolower($key);
+                $key = mb_strtolower((string) $key);
             }
 
             if (! array_key_exists($key, $rules)) {


### PR DESCRIPTION
# Issue that this solves

When using Saloon to request data from [Shopify's GraphQL Storefront API](https://shopify.dev/docs/api/storefront), I am using a general `Fixture` to try and replace a bunch of the headers in the response with the `defineSensitiveHeaders()` function to replace those values with `"null"` so that I'm not committing sensitive info to my repository. However, I get an error when running my tests using these fixtures, because the [recursivelyReplaceAttributes() function](https://github.com/saloonphp/saloon/blob/ea50417e85aeaa4280b8ff8e916162a667603c99/src/Helpers/FixtureHelper.php#L19C28-L19C56) in the `src/Helpers/FixtureHelper.php` file throws an error on headers that have arrays as values while it walks the array of Headers recursively. It seems as though the issue it's having is because it gets an `int` as the header's `$key` for those headers that are in a regular array, not an associative one. I've implemented a one line fix in this PR that solved the issue for me locally in my `vendor` folder, but I am also quite new to PHP so there might be a much more robust solution than the simple type-cast that I did here. Loving using Saloon for wranging my Shopify integration, thanks for all your hard work on this project @Sammyjo20! If you'd like a more detailed reproduction of this, I'd be more than happy to provide one, I just wanted to get this up while I had some time today before I forget exactly what was going wrong. 

<details>
<summary>Error message when running tests</summary>

![image](https://github.com/saloonphp/saloon/assets/37027883/b3019357-192e-44a2-a6ad-0d4e157f61bb)

</details>

<details>
<summary>JSON response blob</summary>

```json
{
    "statusCode": 200,
    "headers": {
        "Date": "null",
        "Content-Type": "application/json; charset=utf-8",
        "Transfer-Encoding": "chunked",
        "Connection": "keep-alive",
        "X-Sorting-Hat-PodId": "null",
        "X-Sorting-Hat-ShopId": "null",
        "X-Storefront-Renderer-Rendered": "null",
        "Vary": [
            "Accept-Encoding",
            "Accept"
        ],
        "x-frame-options": "DENY",
        "content-security-policy": "block-all-mixed-content; frame-ancestors 'none'; upgrade-insecure-requests;",
        "access-control-allow-origin": "*",
        "x-shopify-api-version": "null",
        "x-cache": "hit, server",
        "x-shopid": "null",
        "x-shardid": "null",
        "content-language": "en",
        "powered-by": "Shopify",
        "server-timing": [
            "ipv6"
        ],
        "x-dc": "null",
        "x-request-id": "null",
        "CF-Cache-Status": "DYNAMIC",
        "Report-To": "null",
        "NEL": "null",
        "X-XSS-Protection": "1; mode=block",
        "X-Content-Type-Options": "nosniff",
        "X-Permitted-Cross-Domain-Policies": "none",
        "X-Download-Options": "noopen",
        "Server": "cloudflare",
        "CF-RAY": "null",
        "alt-svc": "h3=\":443\"; ma=86400"
    },
    "data": "{\"data\":{\"collection\":{\"products\":{\"nodes\":[{\"handle\":\"guatemala\",\"title\":\"Guatemala\",\"featuredImage\":{\"url\":\"https://cdn.shopify.com/s/files/1/0704/1322/2107/files/summer-solstice.jpg?v=1718145615\",\"altText\":null,\"height\":500,\"width\":500},\"variantBySelectedOptions\":{\"price\":{\"amount\":\"30.0\",\"currencyCode\":\"USD\"}}},{\"handle\":\"bolivia\",\"title\":\"Bolivia\",\"featuredImage\":{\"url\":\"https://cdn.shopify.com/s/files/1/0704/1322/2107/files/summer-solstice.jpg?v=1718145615\",\"altText\":null,\"height\":500,\"width\":500},\"variantBySelectedOptions\":{\"price\":{\"amount\":\"21.0\",\"currencyCode\":\"USD\"}}},{\"handle\":\"solstice-blend\",\"title\":\"Summer Solstice\",\"featuredImage\":{\"url\":\"https://cdn.shopify.com/s/files/1/0704/1322/2107/files/summer-solstice.jpg?v=1718145615\",\"altText\":null,\"height\":500,\"width\":500},\"variantBySelectedOptions\":{\"price\":{\"amount\":\"22.0\",\"currencyCode\":\"USD\"}}}]}}}}"
}
```

</details>
