### PR TITLE
Feature | Fatal Exception Middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "friendsofphp/php-cs-fixer": "^3.5",
         "illuminate/collections": "^9.39 || ^10.0",
         "league/flysystem": "^3.0",
-        "pestphp/pest": "^2.6",
+        "pestphp/pest": "^2.9",
         "phpstan/phpstan": "^1.11.4",
         "saloonphp/xml-wrangler": "^1.1",
         "spatie/ray": "^1.33",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "friendsofphp/php-cs-fixer": "^3.5",
         "illuminate/collections": "^9.39 || ^10.0",
         "league/flysystem": "^3.0",
-        "pestphp/pest": "^2.9",
+        "pestphp/pest": "^2.10",
         "phpstan/phpstan": "^1.11.4",
         "saloonphp/xml-wrangler": "^1.1",
         "spatie/ray": "^1.33",

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Saloon\Helpers;
 
-use Saloon\Exceptions\Request\FatalRequestException;
 use Saloon\Http\Response;
 use Saloon\Enums\PipeOrder;
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\FakeResponse;
+use Saloon\Exceptions\Request\FatalRequestException;
 
 class MiddlewarePipeline
 {
@@ -149,8 +149,6 @@ class MiddlewarePipeline
     public function executeFatalPipeline(FatalRequestException $throwable): void
     {
         $this->fatalPipeline->process($throwable);
-
-        throw $throwable;
     }
 
     /**

--- a/src/Helpers/MiddlewarePipeline.php
+++ b/src/Helpers/MiddlewarePipeline.php
@@ -102,7 +102,7 @@ class MiddlewarePipeline
     /**
      * Add a middleware to run on fatal errors
      *
-     * @param callable(\Throwable, \Saloon\Http\PendingRequest): (void) $callable
+     * @param callable(FatalRequestException): (void) $callable
      * @return $this
      */
     public function onFatalException(callable $callable, ?string $name = null, ?PipeOrder $order = null): static

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -23,6 +23,7 @@ use Saloon\Traits\Auth\AuthenticatesRequests;
 use Saloon\Http\Middleware\ValidateProperties;
 use Saloon\Http\Middleware\DetermineMockResponse;
 use Saloon\Exceptions\InvalidResponseClassException;
+use Saloon\Exceptions\Request\FatalRequestException;
 use Saloon\Traits\PendingRequest\ManagesPsrRequests;
 use Saloon\Http\PendingRequest\MergeRequestProperties;
 use Saloon\Http\PendingRequest\BootConnectorAndRequest;
@@ -150,6 +151,14 @@ class PendingRequest
     public function executeResponsePipeline(Response $response): Response
     {
         return $this->middleware()->executeResponsePipeline($response);
+    }
+
+    /**
+     * Execute the fatal pipeline.
+     */
+    public function executeFatalPipeline(FatalRequestException $throwable): void
+    {
+        $this->middleware()->executeFatalPipeline($throwable);
     }
 
     /**

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -92,11 +92,15 @@ trait SendsRequests
 
                 $exceptionResponse = $exception instanceof RequestException ? $exception->getResponse() : null;
 
+                // If the exception is a FatalRequestException, we'll execute the fatal pipeline
+                if($exception instanceof FatalRequestException) {
+                    $exception->getPendingRequest()->executeFatalPipeline($exception);
+                }
+
                 // If we've reached our max attempts - we won't try again, but we'll either
                 // return the last response made or just throw an exception.
 
                 if ($attempts === $maxTries) {
-                    $this->middleware()->executeFatalPipeline($exception, $request);
                     return isset($exceptionResponse) && $throwOnMaxTries === false ? $exceptionResponse : throw $exception;
                 }
 

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -96,6 +96,7 @@ trait SendsRequests
                 // return the last response made or just throw an exception.
 
                 if ($attempts === $maxTries) {
+                    $this->middleware()->executeFatalPipeline($exception, $request);
                     return isset($exceptionResponse) && $throwOnMaxTries === false ? $exceptionResponse : throw $exception;
                 }
 


### PR DESCRIPTION
This adds a new `onFatalException` middleware option that will be run went a fatal error occurs. 

Example Usage:

```php
Config::globalMiddleware()
    ->onFatalException(function (FatalRequestException $exception) {
        // do something 
    }, 'test', PipeOrder::FIRST); 
```

This could be used to notify someone or log errors. 

Introduced usage of `describe` to tidy / group tests however this required bumping the minimum PestPHP version from 2.6 to 2.9 