### PR TITLE
Add `PaymentRequired` Exception

### DIFF
--- a/src/Exceptions/Request/Statuses/PaymentRequiredException.php
+++ b/src/Exceptions/Request/Statuses/PaymentRequiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Exceptions\Request\Statuses;
+
+use Saloon\Exceptions\Request\ClientException;
+
+class PaymentRequiredException extends ClientException
+{
+    //
+}

--- a/src/Helpers/RequestExceptionHelper.php
+++ b/src/Helpers/RequestExceptionHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Helpers;
 
+use Saloon\Exceptions\Request\Statuses\PaymentRequiredException;
 use Throwable;
 use Saloon\Http\Response;
 use Saloon\Exceptions\Request\ClientException;
@@ -32,6 +33,7 @@ class RequestExceptionHelper
         $requestException = match (true) {
             // Built-in exceptions
             $status === 401 => UnauthorizedException::class,
+            $status === 402 => PaymentRequiredException::class,
             $status === 403 => ForbiddenException::class,
             $status === 404 => NotFoundException::class,
             $status === 405 => MethodNotAllowedException::class,

--- a/src/Helpers/RequestExceptionHelper.php
+++ b/src/Helpers/RequestExceptionHelper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Saloon\Helpers;
 
-use Saloon\Exceptions\Request\Statuses\PaymentRequiredException;
 use Throwable;
 use Saloon\Http\Response;
 use Saloon\Exceptions\Request\ClientException;
@@ -15,6 +14,7 @@ use Saloon\Exceptions\Request\Statuses\ForbiddenException;
 use Saloon\Exceptions\Request\Statuses\UnauthorizedException;
 use Saloon\Exceptions\Request\Statuses\GatewayTimeoutException;
 use Saloon\Exceptions\Request\Statuses\RequestTimeOutException;
+use Saloon\Exceptions\Request\Statuses\PaymentRequiredException;
 use Saloon\Exceptions\Request\Statuses\TooManyRequestsException;
 use Saloon\Exceptions\Request\Statuses\MethodNotAllowedException;
 use Saloon\Exceptions\Request\Statuses\ServiceUnavailableException;

--- a/tests/Unit/RequestExceptionTest.php
+++ b/tests/Unit/RequestExceptionTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Saloon\Exceptions\Request\Statuses\PaymentRequiredException;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Helpers\StatusCodeHelper;
 use Saloon\Http\Faking\MockResponse;
@@ -16,6 +15,7 @@ use Saloon\Tests\Fixtures\Requests\AlwaysHasFailureRequest;
 use Saloon\Exceptions\Request\Statuses\UnauthorizedException;
 use Saloon\Exceptions\Request\Statuses\GatewayTimeoutException;
 use Saloon\Exceptions\Request\Statuses\RequestTimeOutException;
+use Saloon\Exceptions\Request\Statuses\PaymentRequiredException;
 use Saloon\Exceptions\Request\Statuses\TooManyRequestsException;
 use Saloon\Exceptions\Request\Statuses\MethodNotAllowedException;
 use Saloon\Exceptions\Request\Statuses\ServiceUnavailableException;

--- a/tests/Unit/RequestExceptionTest.php
+++ b/tests/Unit/RequestExceptionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Saloon\Exceptions\Request\Statuses\PaymentRequiredException;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Helpers\StatusCodeHelper;
 use Saloon\Http\Faking\MockResponse;
@@ -30,11 +31,12 @@ test('the response will return different exceptions based on status', function (
     $exception = $response->toException();
 
     $message = sprintf('%s (%s) Response: %s', StatusCodeHelper::getMessage($status), $status, $response->body());
-    
+
     expect($exception)->toBeInstanceOf($expectedException);
     expect($exception->getMessage())->toEqual($message);
 })->with([
     [401, UnauthorizedException::class],
+    [402, PaymentRequiredException::class],
     [403, ForbiddenException::class],
     [404, NotFoundException::class],
     [405, MethodNotAllowedException::class],
@@ -45,7 +47,7 @@ test('the response will return different exceptions based on status', function (
     [503, ServiceUnavailableException::class],
     [504, GatewayTimeoutException::class],
     [418, ClientException::class],
-    [402, ClientException::class],
+    [411, ClientException::class],
 ]);
 
 test('when the failed method is customised the response will return ok request exceptions', function (int $status, string $expectedException) {


### PR DESCRIPTION
This PR adds an Exception for 402 Payment Required so rather than it returning a `ClientException`, it'll now return `PaymentRequiredException`. I'm working with an API that returns this status code and I'd like to be able to handle these in a certain way, this status also seems to be getting more popular these days, so I think it makes sense for it to now have it's own Exception.

Before
![Screenshot 2024-07-28 at 23 48 51](https://github.com/user-attachments/assets/acb578b8-c37d-410a-bf67-9e3b11f01138)

After
![Screenshot 2024-07-28 at 23 48 04](https://github.com/user-attachments/assets/9c5f5649-8240-4437-bff5-13fb711ff3e3)

Sister PR to https://github.com/Sammyjo20/saloon-docs/pull/71
