### PR TITLE
Replace deprecated auth methods in tests

### DIFF
--- a/tests/Feature/AuthenticatesRequestsTest.php
+++ b/tests/Feature/AuthenticatesRequestsTest.php
@@ -7,14 +7,13 @@ use GuzzleHttp\Psr7\HttpFactory;
 use Saloon\Http\Faking\MockResponse;
 use Psr\Http\Message\RequestInterface;
 use GuzzleHttp\Promise\FulfilledPromise;
+use Saloon\Http\Auth\DigestAuthenticator;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
 
 test('you can provide digest authentication and guzzle will send it', function () {
     $connector = new TestConnector;
-    $request = new UserRequest;
-
-    $request->withDigestAuth('Sammyjo20', 'Cowboy1', 'Howdy');
+    $request = UserRequest::make()->authenticate(new DigestAuthenticator('Sammyjo20', 'Cowboy1', 'Howdy'));
 
     $asserted = false;
 

--- a/tests/Fixtures/Plugins/AuthenticatorPlugin.php
+++ b/tests/Fixtures/Plugins/AuthenticatorPlugin.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Saloon\Tests\Fixtures\Plugins;
 
 use Saloon\Http\PendingRequest;
+use Saloon\Http\Auth\TokenAuthenticator;
 
 trait AuthenticatorPlugin
 {
     public function bootAuthenticatorPlugin(PendingRequest $pendingRequest): void
     {
-        $pendingRequest->withTokenAuth('plugin-auth');
+        $pendingRequest->authenticate(new TokenAuthenticator('plugin-auth'));
     }
 }

--- a/tests/Fixtures/Requests/BootAuthenticatorRequest.php
+++ b/tests/Fixtures/Requests/BootAuthenticatorRequest.php
@@ -9,6 +9,7 @@ use Saloon\Http\Request;
 use Saloon\Http\PendingRequest;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Traits\Body\HasJsonBody;
+use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Tests\Fixtures\Connectors\TestConnector;
 
 class BootAuthenticatorRequest extends Request implements HasBody
@@ -36,6 +37,6 @@ class BootAuthenticatorRequest extends Request implements HasBody
 
     public function boot(PendingRequest $pendingRequest): void
     {
-        $pendingRequest->withTokenAuth('howdy-partner');
+        $pendingRequest->authenticate(new TokenAuthenticator('howdy-partner'));
     }
 }

--- a/tests/Unit/AuthenticatesRequestsTest.php
+++ b/tests/Unit/AuthenticatesRequestsTest.php
@@ -5,16 +5,19 @@ declare(strict_types=1);
 use GuzzleHttp\RequestOptions;
 use Saloon\Exceptions\SaloonException;
 use Saloon\Http\Auth\NullAuthenticator;
+use Saloon\Http\Auth\BasicAuthenticator;
 use Saloon\Http\Auth\MultiAuthenticator;
+use Saloon\Http\Auth\QueryAuthenticator;
 use Saloon\Http\Auth\TokenAuthenticator;
+use Saloon\Http\Auth\DigestAuthenticator;
 use Saloon\Http\Auth\HeaderAuthenticator;
+use Saloon\Http\Auth\CertificateAuthenticator;
 use Saloon\Tests\Fixtures\Requests\UserRequest;
 use Saloon\Tests\Fixtures\Connectors\ArraySenderConnector;
 use Saloon\Tests\Fixtures\Connectors\DefaultAuthenticatorConnector;
 
 test('you can add basic auth to a request', function () {
-    $request = new UserRequest;
-    $request->withBasicAuth('Sammyjo20', 'Cowboy1');
+    $request = UserRequest::make()->authenticate(new BasicAuthenticator('Sammyjo20', 'Cowboy1'));
 
     $pendingRequest = connector()->createPendingRequest($request);
     $headers = $pendingRequest->headers()->all();
@@ -24,7 +27,7 @@ test('you can add basic auth to a request', function () {
 });
 
 test('you can attach an authorization token to a request', function () {
-    $request = UserRequest::make()->withTokenAuth('Sammyjo20');
+    $request = UserRequest::make()->authenticate(new TokenAuthenticator('Sammyjo20'));
 
     $pendingRequest = connector()->createPendingRequest($request);
     $headers = $pendingRequest->headers()->all();
@@ -33,8 +36,7 @@ test('you can attach an authorization token to a request', function () {
 });
 
 test('you can add digest auth to a request', function () {
-    $request = new UserRequest;
-    $request->withDigestAuth('Sammyjo20', 'Cowboy1', 'Howdy');
+    $request = UserRequest::make()->authenticate(new DigestAuthenticator('Sammyjo20', 'Cowboy1', 'Howdy'));
 
     $pendingRequest = connector()->createPendingRequest($request);
     $config = $pendingRequest->config()->all();
@@ -51,7 +53,7 @@ test('you can add digest auth to a request', function () {
 })->throws(SaloonException::class, 'The DigestAuthenticator is only supported when using the GuzzleSender.');
 
 test('you can add a token to a query parameter', function () {
-    $request = UserRequest::make()->withQueryAuth('token', 'Sammyjo20');
+    $request = UserRequest::make()->authenticate(new QueryAuthenticator('token', 'Sammyjo20'));
 
     $pendingRequest = connector()->createPendingRequest($request);
     $query = $pendingRequest->query()->all();
@@ -60,7 +62,7 @@ test('you can add a token to a query parameter', function () {
 });
 
 test('you can add a header to a request', function () {
-    $request = UserRequest::make()->withHeaderAuth('Sammyjo20', 'X-Authorization');
+    $request = UserRequest::make()->authenticate(new HeaderAuthenticator('Sammyjo20', 'X-Authorization'));
 
     $pendingRequest = connector()->createPendingRequest($request);
     $query = $pendingRequest->headers()->all();
@@ -71,7 +73,7 @@ test('you can add a header to a request', function () {
 test('you can add a certificate to a request', function () {
     $certPath = __DIR__ . '/certificate.cer';
 
-    $requestA = UserRequest::make()->withCertificateAuth($certPath);
+    $requestA = UserRequest::make()->authenticate(new CertificateAuthenticator($certPath));
 
     $pendingRequestA = connector()->createPendingRequest($requestA);
     $configA = $pendingRequestA->config()->all();
@@ -82,7 +84,7 @@ test('you can add a certificate to a request', function () {
 
     // Test with password
 
-    $requestB = UserRequest::make()->withCertificateAuth($certPath, 'example');
+    $requestB = UserRequest::make()->authenticate(new CertificateAuthenticator($certPath, 'example'));
 
     $pendingRequestB = connector()->createPendingRequest($requestB);
     $configB = $pendingRequestB->config()->all();

--- a/tests/Unit/AuthenticatorTest.php
+++ b/tests/Unit/AuthenticatorTest.php
@@ -46,7 +46,7 @@ test('you can provide an authenticator on the fly and it will take priority over
     $request = new DefaultAuthenticatorRequest();
     $connector = new DefaultAuthenticatorConnector;
 
-    $request->withTokenAuth('yee-haw-on-the-fly', 'PewPew');
+    $request->authenticate(new TokenAuthenticator('yee-haw-on-the-fly', 'PewPew'));
 
     $pendingRequest = $connector->createPendingRequest($request);
 
@@ -120,7 +120,7 @@ test('you can customise the authenticator inside of a middleware pipeline', func
 
     $request->middleware()
         ->onRequest(function (PendingRequest $pendingRequest) {
-            $pendingRequest->withTokenAuth('ooh-this-is-cool');
+            $pendingRequest->authenticate(new TokenAuthenticator('ooh-this-is-cool'));
         });
 
     $pendingRequest = connector()->createPendingRequest($request);
@@ -133,7 +133,7 @@ test('you can add an authenticator inside of request middleware', function () {
     $request = new UserRequest;
 
     $request->middleware()->onRequest(function (PendingRequest $pendingRequest) {
-        return $pendingRequest->withTokenAuth('yee-haw-request');
+        return $pendingRequest->authenticate(new TokenAuthenticator('yee-haw-request'));
     });
 
     $pendingRequest = connector()->createPendingRequest($request);


### PR DESCRIPTION
This PR replaces deprecated auth methods (see #368) in tests with their `authenticate()` equivalents.