### PR TITLE
Feature | Add methods to dynamically set/unset retry options

### DIFF
--- a/src/Traits/RequestProperties/HasTries.php
+++ b/src/Traits/RequestProperties/HasTries.php
@@ -60,7 +60,7 @@ trait HasTries
         return $this;
     }
     
-    public function withExponentialBackoff(?bool $exponentialBackoff): static
+    public function withExponentialBackoff(?bool $exponentialBackoff = true): static
     {
         $this->useExponentialBackoff = $exponentialBackoff;
 
@@ -91,6 +91,16 @@ trait HasTries
         }
 
         return $this;
+    }
+
+    public function withoutRetryInterval(): static
+    {
+        return $this->withRetryInterval(null);
+    }
+    
+    public function withoutExponentialBackoff(): static
+    {
+        return $this->withExponentialBackoff(false);
     }
 
     public function withoutRetry(): static

--- a/src/Traits/RequestProperties/HasTries.php
+++ b/src/Traits/RequestProperties/HasTries.php
@@ -52,4 +52,49 @@ trait HasTries
     {
         return true;
     }
+
+    public function withRetryInterval(?int $milliseconds): static
+    {
+        $this->retryInterval = $milliseconds;
+
+        return $this;
+    }
+    
+    public function withExponentialBackoff(?bool $exponentialBackoff): static
+    {
+        $this->useExponentialBackoff = $exponentialBackoff;
+
+        return $this;
+    }
+
+    public function throwOnMaxTries(?bool $throwOnMaxTries): static
+    {
+        $this->throwOnMaxTries = $throwOnMaxTries;
+
+        return $this;
+    }
+
+    public function withRetry(?int $tries, ?int $intervalMilliseconds = null, ?bool $exponentialBackoff = null, ?bool $throwOnMaxTries = null): static
+    {
+        $this->tries = $tries;
+
+        if ($intervalMilliseconds) {
+            $this->withRetryInterval($intervalMilliseconds);
+        }
+
+        if ($exponentialBackoff) {
+            $this->withExponentialBackoff($exponentialBackoff);
+        }
+
+        if ($throwOnMaxTries) {
+            $this->throwOnMaxTries($throwOnMaxTries);
+        }
+
+        return $this;
+    }
+
+    public function withoutRetry(): static
+    {
+        return $this->withRetry(null);
+    }
 }

--- a/src/Traits/RequestProperties/HasTries.php
+++ b/src/Traits/RequestProperties/HasTries.php
@@ -67,7 +67,7 @@ trait HasTries
         return $this;
     }
 
-    public function throwOnMaxTries(?bool $throwOnMaxTries): static
+    public function throwOnMaxTries(?bool $throwOnMaxTries = true): static
     {
         $this->throwOnMaxTries = $throwOnMaxTries;
 


### PR DESCRIPTION
This PR adds methods in the `HasTries` trait to allow the retry options to be set dynamically (mainly when using resources)

```php
$this->connector
	->withRetry(tries: 3, intervalMilliseconds: 1000, exponentialBackoff: true, , throwOnMaxTries: true)
	->admin()
	->externalProducts()
	->upsertExternalProduct($productId, $data);


$this->connector
	->withRetry(3)
	->withRetryInterval(1000)
	->withExponentialBackoff()
	->throwOnMaxTries()
	->admin()
	->externalProducts()
	->upsertExternalProduct($productId, $data)
```

This will also allow to unset these options for specific requests

```php
$this->connector
	->withoutRetry()
	->admin()
	->externalProducts()
	->upsertExternalProduct($productId, $data);


$this->connector
	->withRetry(3)
	->withRetryInterval(null)
	->withExponentialBackoff(false)
	->throwOnMaxTries(false)
	->admin()
	->externalProducts()
	->upsertExternalProduct($productId, $data)

$this->connector
	->withRetry(3)
	->withoutRetryInterval()
	->withoutExponentialBackoff()
	->throwOnMaxTries(false)
	->admin()
	->externalProducts()
	->upsertExternalProduct($productId, $data)
```

This is just a draft PR, it would still be missing tests and method comments to follow the other methods in the trait, I will happily add them if you thing this would be a good addition

To Do:
- [ ] Tests
- [ ] Method docblocks