### PR TITLE
Renamed $response to $responseClass for better clarity

### DIFF
--- a/src/Http/Connector.php
+++ b/src/Http/Connector.php
@@ -14,7 +14,7 @@ use Saloon\Traits\ManagesExceptions;
 use Saloon\Traits\Connector\SendsRequests;
 use Saloon\Traits\Auth\AuthenticatesRequests;
 use Saloon\Traits\RequestProperties\HasTries;
-use Saloon\Traits\Responses\HasCustomResponses;
+use Saloon\Traits\Responses\HasResponseClass;
 use Saloon\Traits\Request\CreatesDtoFromResponse;
 use Saloon\Traits\RequestProperties\HasRequestProperties;
 
@@ -23,7 +23,7 @@ abstract class Connector
     use CreatesDtoFromResponse;
     use AuthenticatesRequests;
     use HasRequestProperties;
-    use HasCustomResponses;
+    use HasResponseClass;
     use ManagesExceptions;
     use HandlesPsrRequest;
     use HasMockClient;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -15,7 +15,7 @@ use Saloon\Traits\HandlesPsrRequest;
 use Saloon\Traits\ManagesExceptions;
 use Saloon\Traits\Auth\AuthenticatesRequests;
 use Saloon\Traits\RequestProperties\HasTries;
-use Saloon\Traits\Responses\HasCustomResponses;
+use Saloon\Traits\Responses\HasResponseClass;
 use Saloon\Traits\Request\CreatesDtoFromResponse;
 use Saloon\Traits\RequestProperties\HasRequestProperties;
 
@@ -24,7 +24,7 @@ abstract class Request
     use CreatesDtoFromResponse;
     use AuthenticatesRequests;
     use HasRequestProperties;
-    use HasCustomResponses;
+    use HasResponseClass;
     use ManagesExceptions;
     use HandlesPsrRequest;
     use HasMockClient;

--- a/src/Traits/Responses/HasCustomResponses.php
+++ b/src/Traits/Responses/HasCustomResponses.php
@@ -7,13 +7,13 @@ namespace Saloon\Traits\Responses;
 trait HasCustomResponses
 {
     /**
-     * Specify a default response.
+     * Specify a default response class.
      *
      * When null or an empty string, the response on the sender will be used.
      *
      * @var class-string<\Saloon\Http\Response>|null
      */
-    protected ?string $response = null;
+    protected ?string $responseClass = null;
 
     /**
      * Resolve the custom response class
@@ -22,6 +22,6 @@ trait HasCustomResponses
      */
     public function resolveResponseClass(): ?string
     {
-        return $this->response ?? null;
+        return $this->responseClass ?? null;
     }
 }

--- a/src/Traits/Responses/HasResponseClass.php
+++ b/src/Traits/Responses/HasResponseClass.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Saloon\Traits\Responses;
 
-trait HasCustomResponses
+trait HasResponseClass
 {
     /**
      * Specify a default response class.


### PR DESCRIPTION
Reflects improved naming for better code readability and maintainability