### PR TITLE
Fix | Resolve PHP 8.4 deprecation warnings

### DIFF
--- a/src/Exceptions/InvalidResponseClassException.php
+++ b/src/Exceptions/InvalidResponseClassException.php
@@ -11,7 +11,7 @@ class InvalidResponseClassException extends SaloonException
     /**
      * Constructor
      */
-    public function __construct(string $message = null)
+    public function __construct(?string $message = null)
     {
         parent::__construct($message ?? sprintf('The provided response must exist and implement the %s contract.', Response::class));
     }

--- a/src/Exceptions/InvalidStateException.php
+++ b/src/Exceptions/InvalidStateException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class InvalidStateException extends SaloonException
 {
-    public function __construct(string $message = null, int $code = 0, ?Throwable $previous = null)
+    public function __construct(?string $message = null, int $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message ?? 'Invalid state.', $code, $previous);
     }

--- a/src/Helpers/RequestExceptionHelper.php
+++ b/src/Helpers/RequestExceptionHelper.php
@@ -26,7 +26,7 @@ class RequestExceptionHelper
     /**
      * Create the request exception from a response
      */
-    public static function create(Response $response, Throwable $previous = null): RequestException
+    public static function create(Response $response, ?Throwable $previous = null): RequestException
     {
         $status = $response->status();
 

--- a/src/Http/Faking/Fixture.php
+++ b/src/Http/Faking/Fixture.php
@@ -31,7 +31,7 @@ class Fixture
     /**
      * Constructor
      */
-    public function __construct(string $name = '', Storage $storage = null)
+    public function __construct(string $name = '', ?Storage $storage = null)
     {
         $this->name = $name;
         $this->storage = $storage ?? new Storage(MockConfig::getFixturePath(), true);

--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -300,7 +300,7 @@ class MockClient
     /**
      * Assert a request count has been met.
      */
-    public function assertSentCount(int $count, string $requestClass = null): void
+    public function assertSentCount(int $count, ?string $requestClass = null): void
     {
         if (is_string($requestClass)) {
             $actualCount = $this->getRequestSentCount()[$requestClass] ?? 0;

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -77,7 +77,7 @@ class PendingRequest
     /**
      * Build up the request payload.
      */
-    public function __construct(Connector $connector, Request $request, MockClient $mockClient = null)
+    public function __construct(Connector $connector, Request $request, ?MockClient $mockClient = null)
     {
         // Let's start by getting our PSR factory collection. This object contains all the
         // relevant factories for creating PSR-7 requests as well as URIs and streams.

--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -82,7 +82,7 @@ class Response
     /**
      * Create a new response instance.
      */
-    public function __construct(ResponseInterface $psrResponse, PendingRequest $pendingRequest, RequestInterface $psrRequest, Throwable $senderException = null)
+    public function __construct(ResponseInterface $psrResponse, PendingRequest $pendingRequest, RequestInterface $psrRequest, ?Throwable $senderException = null)
     {
         $this->psrRequest = $psrRequest;
         $this->psrResponse = $psrResponse;

--- a/src/Http/Senders/GuzzleSender.php
+++ b/src/Http/Senders/GuzzleSender.php
@@ -180,7 +180,7 @@ class GuzzleSender implements Sender
     /**
      * Create a response.
      */
-    protected function createResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, RequestInterface $psrRequest, Exception $exception = null): Response
+    protected function createResponse(ResponseInterface $psrResponse, PendingRequest $pendingRequest, RequestInterface $psrRequest, ?Exception $exception = null): Response
     {
         /** @var class-string<\Saloon\Http\Response> $responseClass */
         $responseClass = $pendingRequest->getResponseClass();

--- a/src/Repositories/Body/MultipartBodyRepository.php
+++ b/src/Repositories/Body/MultipartBodyRepository.php
@@ -40,7 +40,7 @@ class MultipartBodyRepository implements BodyRepository, MergeableBody
      * @param array<\Saloon\Data\MultipartValue> $value
      * @throws \Exception
      */
-    public function __construct(array $value = [], string $boundary = null)
+    public function __construct(array $value = [], ?string $boundary = null)
     {
         $this->data = new ArrayBodyRepository;
         $this->boundary = is_null($boundary) ? StringHelpers::random(40) : $boundary;
@@ -90,7 +90,7 @@ class MultipartBodyRepository implements BodyRepository, MergeableBody
      * @param array<string, mixed> $headers
      * @return $this
      */
-    public function add(string $name, mixed $contents, string $filename = null, array $headers = []): static
+    public function add(string $name, mixed $contents, ?string $filename = null, array $headers = []): static
     {
         $this->attach(new MultipartValue($name, $contents, $filename, $headers));
 

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -26,7 +26,7 @@ trait SendsRequests
      *
      * @param callable(\Throwable, \Saloon\Http\Request): (bool)|null $handleRetry
      */
-    public function send(Request $request, MockClient $mockClient = null, callable $handleRetry = null): Response
+    public function send(Request $request, ?MockClient $mockClient = null, callable $handleRetry = null): Response
     {
         if (is_null($handleRetry)) {
             $handleRetry = static fn (): bool => true;
@@ -126,7 +126,7 @@ trait SendsRequests
     /**
      * Send a request asynchronously
      */
-    public function sendAsync(Request $request, MockClient $mockClient = null): PromiseInterface
+    public function sendAsync(Request $request, ?MockClient $mockClient = null): PromiseInterface
     {
         $sender = $this->sender();
 
@@ -163,7 +163,7 @@ trait SendsRequests
      *
      * @param callable(\Throwable, \Saloon\Http\Request): (bool)|null $handleRetry
      */
-    public function sendAndRetry(Request $request, int $tries, int $interval = 0, callable $handleRetry = null, bool $throw = true, MockClient $mockClient = null, bool $useExponentialBackoff = false): Response
+    public function sendAndRetry(Request $request, int $tries, int $interval = 0, callable $handleRetry = null, bool $throw = true, ?MockClient $mockClient = null, bool $useExponentialBackoff = false): Response
     {
         $request->tries = $tries;
         $request->retryInterval = $interval;
@@ -176,7 +176,7 @@ trait SendsRequests
     /**
      * Create a new PendingRequest
      */
-    public function createPendingRequest(Request $request, MockClient $mockClient = null): PendingRequest
+    public function createPendingRequest(Request $request, ?MockClient $mockClient = null): PendingRequest
     {
         return new PendingRequest($this, $request, $mockClient);
     }

--- a/src/Traits/Connector/SendsRequests.php
+++ b/src/Traits/Connector/SendsRequests.php
@@ -26,7 +26,7 @@ trait SendsRequests
      *
      * @param callable(\Throwable, \Saloon\Http\Request): (bool)|null $handleRetry
      */
-    public function send(Request $request, ?MockClient $mockClient = null, callable $handleRetry = null): Response
+    public function send(Request $request, ?MockClient $mockClient = null, ?callable $handleRetry = null): Response
     {
         if (is_null($handleRetry)) {
             $handleRetry = static fn (): bool => true;
@@ -163,7 +163,7 @@ trait SendsRequests
      *
      * @param callable(\Throwable, \Saloon\Http\Request): (bool)|null $handleRetry
      */
-    public function sendAndRetry(Request $request, int $tries, int $interval = 0, callable $handleRetry = null, bool $throw = true, ?MockClient $mockClient = null, bool $useExponentialBackoff = false): Response
+    public function sendAndRetry(Request $request, int $tries, int $interval = 0, ?callable $handleRetry = null, bool $throw = true, ?MockClient $mockClient = null, bool $useExponentialBackoff = false): Response
     {
         $request->tries = $tries;
         $request->retryInterval = $interval;

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -33,7 +33,7 @@ trait AuthorizationCodeGrant
      *
      * @param array<string> $scopes
      */
-    public function getAuthorizationUrl(array $scopes = [], string $state = null, string $scopeSeparator = ' ', array $additionalQueryParameters = []): string
+    public function getAuthorizationUrl(array $scopes = [], ?string $state = null, string $scopeSeparator = ' ', array $additionalQueryParameters = []): string
     {
         $config = $this->oauthConfig();
 
@@ -72,7 +72,7 @@ trait AuthorizationCodeGrant
      * @param callable(TRequest): (void)|null $requestModifier
      * @throws \Saloon\Exceptions\InvalidStateException
      */
-    public function getAccessToken(string $code, string $state = null, string $expectedState = null, bool $returnResponse = false, ?callable $requestModifier = null): OAuthAuthenticator|Response
+    public function getAccessToken(string $code, ?string $state = null, ?string $expectedState = null, bool $returnResponse = false, ?callable $requestModifier = null): OAuthAuthenticator|Response
     {
         $this->oauthConfig()->validate();
 
@@ -140,7 +140,7 @@ trait AuthorizationCodeGrant
     /**
      * Create the OAuthAuthenticator from a response.
      */
-    protected function createOAuthAuthenticatorFromResponse(Response $response, string $fallbackRefreshToken = null): OAuthAuthenticator
+    protected function createOAuthAuthenticatorFromResponse(Response $response, ?string $fallbackRefreshToken = null): OAuthAuthenticator
     {
         $responseData = $response->object();
 

--- a/src/Traits/Request/HasConnector.php
+++ b/src/Traits/Request/HasConnector.php
@@ -57,7 +57,7 @@ trait HasConnector
     /**
      * Create a pending request
      */
-    public function createPendingRequest(MockClient $mockClient = null): PendingRequest
+    public function createPendingRequest(?MockClient $mockClient = null): PendingRequest
     {
         return $this->connector()->createPendingRequest($this, $mockClient);
     }
@@ -65,7 +65,7 @@ trait HasConnector
     /**
      * Send a request synchronously
      */
-    public function send(MockClient $mockClient = null): Response
+    public function send(?MockClient $mockClient = null): Response
     {
         return $this->connector()->send($this, $mockClient);
     }
@@ -73,7 +73,7 @@ trait HasConnector
     /**
      * Send a request asynchronously
      */
-    public function sendAsync(MockClient $mockClient = null): PromiseInterface
+    public function sendAsync(?MockClient $mockClient = null): PromiseInterface
     {
         return $this->connector()->sendAsync($this, $mockClient);
     }

--- a/tests/Fixtures/Connectors/RetryConnector.php
+++ b/tests/Fixtures/Connectors/RetryConnector.php
@@ -11,7 +11,7 @@ use Saloon\Exceptions\Request\FatalRequestException;
 
 class RetryConnector extends TestConnector
 {
-    public function __construct(int $tries = null, int $retryInterval = 0, bool $throwOnMaxTries = null, protected ?Closure $handleRetry = null)
+    public function __construct(?int $tries = null, int $retryInterval = 0, ?bool $throwOnMaxTries = null, protected ?Closure $handleRetry = null)
     {
         // These are just for us to test the various retries
 

--- a/tests/Fixtures/Requests/RetryUserRequest.php
+++ b/tests/Fixtures/Requests/RetryUserRequest.php
@@ -26,7 +26,7 @@ class RetryUserRequest extends Request
         return '/user';
     }
 
-    public function __construct(int $tries = null, int $retryInterval = 0, bool $throwOnMaxTries = null, protected ?Closure $handleRetry = null)
+    public function __construct(?int $tries = null, int $retryInterval = 0, ?bool $throwOnMaxTries = null, protected ?Closure $handleRetry = null)
     {
         // These are just for us to test the various retries
 


### PR DESCRIPTION
Resolve PHP 8.4 deprecation warnings by explicitly marking nullable arguments as nullable.

_Edit: It looks like the failing Actions are not specific for my PR, let me know if I need to fix something._