### PR TITLE
Feature | Improve working with queries

### DIFF
--- a/src/Traits/RequestProperties/HasQuery.php
+++ b/src/Traits/RequestProperties/HasQuery.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Saloon\Traits\RequestProperties;
 
-use Saloon\Repositories\ArrayStore;
+use Closure;
 use Saloon\Contracts\ArrayStore as ArrayStoreContract;
+use Saloon\Repositories\ArrayStore;
 
 trait HasQuery
 {
@@ -20,6 +21,16 @@ trait HasQuery
     public function query(): ArrayStoreContract
     {
         return $this->query ??= $this->resolveQueryBuilder()->set($this->defaultQuery());
+    }
+
+    /**
+     * Access the query parameters fluently
+     */
+    public function fluentQuery(?Closure $callback = null): self
+    {
+        $callback($this->query());
+
+        return $this;
     }
 
     /**

--- a/src/Traits/RequestProperties/HasQuery.php
+++ b/src/Traits/RequestProperties/HasQuery.php
@@ -11,6 +11,11 @@ use Saloon\Repositories\ArrayStore;
 trait HasQuery
 {
     /**
+     * Specify the default query builder class
+     */
+    protected string $queryBuilder = ArrayStore::class;
+
+    /**
      * Request Query Parameters
      */
     protected ArrayStoreContract $query;
@@ -20,7 +25,7 @@ trait HasQuery
      */
     public function query(): ArrayStoreContract
     {
-        return $this->query ??= $this->resolveQueryBuilder()->set($this->defaultQuery());
+        return $this->query ??= $this->resolveQueryBuilder();
     }
 
     /**
@@ -38,7 +43,7 @@ trait HasQuery
      */
     protected function resolveQueryBuilder(): ArrayStoreContract
     {
-        return new ArrayStore();
+        return new $this->queryBuilder($this->defaultQuery());
     }
 
     /**

--- a/src/Traits/RequestProperties/HasQuery.php
+++ b/src/Traits/RequestProperties/HasQuery.php
@@ -31,7 +31,7 @@ trait HasQuery
     /**
      * Access the query parameters fluently
      */
-    public function fluentQuery(?Closure $callback = null): self
+    public function fluentQuery(Closure $callback): self
     {
         $callback($this->query());
 

--- a/src/Traits/RequestProperties/HasQuery.php
+++ b/src/Traits/RequestProperties/HasQuery.php
@@ -19,7 +19,15 @@ trait HasQuery
      */
     public function query(): ArrayStoreContract
     {
-        return $this->query ??= new ArrayStore($this->defaultQuery());
+        return $this->query ??= $this->resolveQueryBuilder()->set($this->defaultQuery());
+    }
+
+    /**
+     * Define the query builder class
+     */
+    protected function resolveQueryBuilder(): ArrayStoreContract
+    {
+        return new ArrayStore();
     }
 
     /**

--- a/tests/Fixtures/QueryBuilders/CustomQueryBuilder.php
+++ b/tests/Fixtures/QueryBuilders/CustomQueryBuilder.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\QueryBuilders;
+
+use Saloon\Repositories\ArrayStore;
+
+class CustomQueryBuilder extends ArrayStore
+{
+    public function limit(int $limit): self
+    {
+        $this->add('limit', $limit);
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/Requests/CustomQueryBuilderRequest.php
+++ b/tests/Fixtures/Requests/CustomQueryBuilderRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Saloon\Tests\Fixtures\Requests;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Tests\Fixtures\Connectors\TestConnector;
+use Saloon\Tests\Fixtures\QueryBuilders\CustomQueryBuilder;
+
+class CustomQueryBuilderRequest extends Request
+{
+    /**
+     * Define the method that the request will use.
+     *
+     * @var string
+     */
+    protected Method $method = Method::GET;
+
+    /**
+     * The connector.
+     */
+    protected string $connector = TestConnector::class;
+
+    /**
+     * The query builder.
+     */
+    protected string $queryBuilder = CustomQueryBuilder::class;
+
+    /**
+     * Constructor
+     */
+    public function __construct(readonly public string $endpoint = '/user')
+    {
+        //
+    }
+
+    /**
+     * Define the endpoint for the request.
+     */
+    public function resolveEndpoint(): string
+    {
+        return $this->endpoint;
+    }
+
+    protected function defaultQuery(): array
+    {
+        return [
+            'per_page' => 100,
+        ];
+    }
+}

--- a/tests/Unit/RequestProperties/QueryTest.php
+++ b/tests/Unit/RequestProperties/QueryTest.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use Saloon\Repositories\ArrayStore;
-use Saloon\Tests\Fixtures\Requests\QueryParameterRequest;
 use Saloon\Tests\Fixtures\Connectors\QueryParameterConnector;
+use Saloon\Tests\Fixtures\QueryBuilders\CustomQueryBuilder;
+use Saloon\Tests\Fixtures\Requests\CustomQueryBuilderRequest;
+use Saloon\Tests\Fixtures\Requests\QueryParameterRequest;
 
 test('default query parameters are merged in from a request', function () {
     $request = new QueryParameterRequest();
@@ -79,4 +81,24 @@ test('query parameters can be managed on a connector', function () {
 
     expect($connector->query()->isEmpty())->toBeFalse();
     expect($connector->query()->isNotEmpty())->toBeTrue();
+});
+
+test('it resolves custom query builder class', function () {
+    $request = new CustomQueryBuilderRequest();
+
+    $query = $request->query()->limit(5);
+
+    expect($query)->toBeInstanceOf(CustomQueryBuilder::class);
+    expect($query)->toEqual(new CustomQueryBuilder(['per_page' => 100, 'limit' => 5]));
+});
+
+test('it can add queries fluently', function () {
+    $request = (new CustomQueryBuilderRequest())
+        ->fluentQuery(function ($query) {
+            $query->limit(5)->add('foo', 'bar');
+        });
+
+    expect($request)->toBeInstanceOf(CustomQueryBuilderRequest::class);
+    expect($request->query())->toBeInstanceOf(CustomQueryBuilder::class);
+    expect($request->query())->toEqual(new CustomQueryBuilder(['per_page' => 100, 'limit' => 5, 'foo' => 'bar']));
 });


### PR DESCRIPTION
This PR provides a couple of improvements around working with queries:

- It adds the ability to define custom query builders
- It adds the ability to work with queries fluently

## Custom Query Builder

Defining a custom query builder works similar to defining a [custom response](https://docs.saloon.dev/the-basics/responses#custom-responses). Providing your own query builder allows you to add methods that mirror the supported parameters of the API you're working with. It's also super helpful for autocompletion in your code editor.

Custom query builders are simply extending the `Saloon\Repositories\ArrayStore` that is already being used for queries. This ensures a non-breaking change.


A simple example of a custom query builder:

```php
use Saloon\Repositories\ArrayStore;

class CloudflareStreamQueryBuilder extends ArrayStore
{
    public function limit(int $limit): self
    {
        $this->add('limit', $limit);

        return $this;
    }
}
```

How you'd register the query builder on a connector or request:

```php
class CloudflareStreamRequest extends Request
{
    protected string $queryBuilder = CloudflareStreamQueryBuilder::class;
}
```

How you'd use the query builder:

```php
$request->query()->limit(5)->add('foo', 'bar');
```

## Fluent Query Builder

A new `fluentQuery()` method makes working with queries a little smoother.

From this:

```php
$connector = new CloudflareConnector();

$connector->query()->limit(5)->add('foo', 'bar');
  
$connector->send($request);
```

To this:

```php
new CloudflareConnector()
    ->fluentQuery(fn ($query) => $query->limit(5)->add('foo', 'bar'))
    ->send($request);
```

I'd prefer to simplify things and merge the logic of the `fluentQuery()` method with the `query()` method. But that would require a method signature change and be a breaking change. I'll leave this decision up to you.

## Feature Request: Queries on resources

I'd love to make queries even more powerful by adding support for resources. This would be super powerful for building SDKs. Consider the following scenario, where you've got different resources that each need their own query builder class. Currently, you can only set the query builder on the connector, which sets the query builder for all resources. Or on each request directly, which can be a little tedious.

This is what I'd love to see:

```php
class CloudflareConnector extends Connector
{
    public function video(): VideoResource
    {
        return new VideoResource($this);
    }

    public function audio(): AudioResource
    {
        return new AudioResource($this);
    }
}
```

```php
class VideoResource extends BaseResource
{
    protected string $queryBuilder = VideoQueryBuilder::class;
}
```

```php
class AudioResource extends BaseResource
{
    protected string $queryBuilder = AudioQueryBuilder::class;
}
```

Then you can use it like this:

```php
new CloudflareConnector()
    ->video()
    ->fluentQuery(fn (VideoQueryBuilder $query) => $query->limit(5)->add('foo', 'bar'))
    ->all()
```

I hope this all makes sense. Thanks for your work on Saloon!