### PR TITLE
Make sure multiple assertions can be made on the same request class

### DIFF
--- a/src/Http/Faking/MockClient.php
+++ b/src/Http/Faking/MockClient.php
@@ -463,16 +463,21 @@ class MockClient
         // and call the callable accordingly. We will only fail if it returns `false`.
 
         if ($fqcn = $this->getRequestClass($closure)) {
-            /** @var Response */
+            /** @var Response $response */
             foreach ($this->getRecordedResponses() as $response) {
                 if (get_class($request = $response->getPendingRequest()->getRequest()) !== $fqcn) {
                     continue;
                 }
 
-                return $closure($request, $response) !== false;
-            }
-        }
+                $passed = $closure($request, $response) !== false;
 
+                if ($passed === true) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
         // Let's then check if the latest response resolves the callable
         // with a successful result.
 

--- a/tests/Unit/MockClientTest.php
+++ b/tests/Unit/MockClientTest.php
@@ -267,17 +267,28 @@ test('you can mock normal exceptions', function () {
 test('`assertSent` accepts the request class as a type-hint', function () {
     $mockClient = new MockClient([
         MockResponse::make(['name' => 'Sam']),
+        MockResponse::make(['name' => 'Sam']),
     ]);
 
-    $request = new UserRequest;
-    $request->headers()->add('X-Foo', 'bar');
+    $requestA = new UserRequest;
+    $requestA->headers()->add('X-Foo', 'bar');
+    $requestB = new UserRequest;
+    $requestB->headers()->add('X-Foo', 'two');
 
-    connector()->send($request, $mockClient);
+    connector()->send($requestA, $mockClient);
+    connector()->send($requestB, $mockClient);
 
     $mockClient->assertSent(function (UserRequest $request) {
-        expect($request->headers()->all())->toMatchArray([
-            'X-Foo' => 'bar',
-        ]);
+        $header = $request->headers()->get('X-Foo');
+        expect($header)->toBeIn(['bar', 'two']);
+
+        return $header === 'bar';
+    });
+    $mockClient->assertSent(function (UserRequest $request) {
+        $header = $request->headers()->get('X-Foo');
+        expect($header)->toBeIn(['bar', 'two']);
+
+        return $header === 'two';
     });
 });
 


### PR DESCRIPTION
Unfortunately, https://github.com/saloonphp/saloon/pull/424 (released in [v3.11.0](https://github.com/saloonphp/saloon/releases/tag/v3.11.0)) introduced a breaking change in my testsuite:

```php
Saloon::fake([
    MockResponse::make(['data' => ['shipmentKey' => 'ABC123']]),
    MockResponse::make(['data' => ['shipmentKey' => 'ABC123']]),
]);

/// ... Send requests

Saloon::assertSent(fn (GetShipmentKeyRequest $request) => $request->orderItem === 123); // Working
Saloon::assertSent(fn (GetShipmentKeyRequest $request) => $request->orderItem === 234); // Failing
```

The new logic only looks for the first match in the list of pending requests. But later in the code, we can see it is always looping through all requests to see if any of them match. I've copied over this behaviour to the class typehinted assertion.

Adjusted the tests accordingly. Is there a chance we can get this patched in? Thanks in advance and keep up the good work! 🚀 