### PR TITLE
Feature | Add baseUrl to OAuthConfig and Requests

### DIFF
--- a/src/Helpers/OAuth2/OAuthConfig.php
+++ b/src/Helpers/OAuth2/OAuthConfig.php
@@ -32,6 +32,11 @@ class OAuthConfig
     protected string $redirectUri = '';
 
     /**
+     * The Base URL
+     */
+    protected ?string $baseUrl = null;
+
+    /**
      * The endpoint used for the authorization URL.
      */
     protected string $authorizeEndpoint = 'authorize';
@@ -119,6 +124,27 @@ class OAuthConfig
 
         return $this;
     }
+
+    /**
+     * Get the Base URL
+     */
+    public function getBaseUrl(): ?string
+    {
+        return $this->baseUrl;
+    }
+
+    /**
+     * Set the Base URL
+     *
+     * @return $this
+     */
+    public function setBaseUrl(?string $baseUrl): static
+    {
+        $this->baseUrl = $baseUrl;
+
+        return $this;
+    }
+
 
     /**
      * Get the authorization endpoint.

--- a/src/Http/OAuth2/GetAccessTokenRequest.php
+++ b/src/Http/OAuth2/GetAccessTokenRequest.php
@@ -22,6 +22,14 @@ class GetAccessTokenRequest extends Request implements HasBody
     protected Method $method = Method::POST;
 
     /**
+     * Define the base URL for the request.
+     */
+    public function resolveBaseUrl(): ?string
+    {
+        return $this->oauthConfig->getBaseUrl();
+    }
+
+    /**
      * Define the endpoint for the request.
      */
     public function resolveEndpoint(): string

--- a/src/Http/OAuth2/GetClientCredentialsTokenBasicAuthRequest.php
+++ b/src/Http/OAuth2/GetClientCredentialsTokenBasicAuthRequest.php
@@ -24,6 +24,14 @@ class GetClientCredentialsTokenBasicAuthRequest extends Request implements HasBo
     protected Method $method = Method::POST;
 
     /**
+     * Define the base URL for the request.
+     */
+    public function resolveBaseUrl(): ?string
+    {
+        return $this->oauthConfig->getBaseUrl();
+    }
+
+    /**
      * Define the endpoint for the request.
      */
     public function resolveEndpoint(): string

--- a/src/Http/OAuth2/GetClientCredentialsTokenRequest.php
+++ b/src/Http/OAuth2/GetClientCredentialsTokenRequest.php
@@ -22,6 +22,14 @@ class GetClientCredentialsTokenRequest extends Request implements HasBody
     protected Method $method = Method::POST;
 
     /**
+     * Define the base URL for the request.
+     */
+    public function resolveBaseUrl(): ?string
+    {
+        return $this->oauthConfig->getBaseUrl();
+    }
+
+    /**
      * Define the endpoint for the request.
      */
     public function resolveEndpoint(): string

--- a/src/Http/OAuth2/GetRefreshTokenRequest.php
+++ b/src/Http/OAuth2/GetRefreshTokenRequest.php
@@ -22,6 +22,14 @@ class GetRefreshTokenRequest extends Request implements HasBody
     protected Method $method = Method::POST;
 
     /**
+     * Define the base URL for the request.
+     */
+    public function resolveBaseUrl(): ?string
+    {
+        return $this->oauthConfig->getBaseUrl();
+    }
+
+    /**
      * Define the endpoint for the request.
      */
     public function resolveEndpoint(): string

--- a/src/Http/OAuth2/GetUserRequest.php
+++ b/src/Http/OAuth2/GetUserRequest.php
@@ -22,6 +22,14 @@ class GetUserRequest extends Request implements HasBody
     protected Method $method = Method::GET;
 
     /**
+     * Define the base URL for the request.
+     */
+    public function resolveBaseUrl(): ?string
+    {
+        return $this->oauthConfig->getBaseUrl();
+    }
+
+    /**
      * Define the endpoint for the request.
      */
     public function resolveEndpoint(): string

--- a/src/Http/PendingRequest.php
+++ b/src/Http/PendingRequest.php
@@ -89,7 +89,8 @@ class PendingRequest
         $this->connector = $connector;
         $this->request = $request;
         $this->method = $request->getMethod();
-        $this->url = URLHelper::join($this->connector->resolveBaseUrl(), $this->request->resolveEndpoint());
+        $baseUrl = $this->request->resolveBaseUrl() ?? $this->connector->resolveBaseUrl();
+        $this->url = URLHelper::join($baseUrl, $this->request->resolveEndpoint());
         $this->authenticator = $request->getAuthenticator() ?? $connector->getAuthenticator();
         $this->mockClient = $mockClient ?? $request->getMockClient() ?? $connector->getMockClient() ?? MockClient::getGlobal();
 

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -52,6 +52,14 @@ abstract class Request
     }
 
     /**
+     * Define the base URL of the API.
+     */
+    public function resolveBaseUrl(): ?string
+    {
+        return null;
+    }
+
+    /**
      * Define the endpoint for the request.
      */
     abstract public function resolveEndpoint(): string;

--- a/src/Traits/OAuth2/AuthorizationCodeGrant.php
+++ b/src/Traits/OAuth2/AuthorizationCodeGrant.php
@@ -60,7 +60,8 @@ trait AuthorizationCodeGrant
         $query = http_build_query($queryParameters, '', '&', PHP_QUERY_RFC3986);
         $query = trim($query, '?&');
 
-        $url = URLHelper::join($this->resolveBaseUrl(), $config->getAuthorizeEndpoint());
+        $baseUrl = $config->getBaseUrl() ?? $this->resolveBaseUrl();
+        $url = URLHelper::join($baseUrl, $config->getAuthorizeEndpoint());
 
         $glue = str_contains($url, '?') ? '&' : '?';
 

--- a/tests/Unit/Oauth2/OAuthConfigTest.php
+++ b/tests/Unit/Oauth2/OAuthConfigTest.php
@@ -11,6 +11,7 @@ test('all default properties are correct and all getters and setters work proper
     expect($config->getClientId())->toEqual('');
     expect($config->getClientSecret())->toEqual('');
     expect($config->getRedirectUri())->toEqual('');
+    expect($config->getBaseUrl())->toEqual(null);
     expect($config->getAuthorizeEndpoint())->toEqual('authorize');
     expect($config->getTokenEndpoint())->toEqual('token');
     expect($config->getUserEndpoint())->toEqual('user');
@@ -19,6 +20,7 @@ test('all default properties are correct and all getters and setters work proper
     $clientId = 'client-id';
     $clientSecret = 'client-secret';
     $redirectUri = 'https://my-app.saloon.dev/auth/callback';
+    $baseUrl = 'https://my-app.saloon.dev/auth';
     $authorizeEndpoint = 'auth/authorize';
     $tokenEndpoint = 'auth/token';
     $userEndpoint = 'auth/user';
@@ -27,6 +29,7 @@ test('all default properties are correct and all getters and setters work proper
     expect($config->setClientId($clientId))->toEqual($config);
     expect($config->setClientSecret($clientSecret))->toEqual($config);
     expect($config->setRedirectUri($redirectUri))->toEqual($config);
+    expect($config->setBaseUrl($baseUrl))->toEqual($config);
     expect($config->setAuthorizeEndpoint($authorizeEndpoint))->toEqual($config);
     expect($config->setTokenEndpoint($tokenEndpoint))->toEqual($config);
     expect($config->setUserEndpoint($userEndpoint))->toEqual($config);
@@ -35,6 +38,7 @@ test('all default properties are correct and all getters and setters work proper
     expect($config->getClientId())->toEqual($clientId);
     expect($config->getClientSecret())->toEqual($clientSecret);
     expect($config->getRedirectUri())->toEqual($redirectUri);
+    expect($config->getBaseUrl())->toEqual($baseUrl);
     expect($config->getAuthorizeEndpoint())->toEqual($authorizeEndpoint);
     expect($config->getTokenEndpoint())->toEqual($tokenEndpoint);
     expect($config->getUserEndpoint())->toEqual($userEndpoint);


### PR DESCRIPTION
This PR introduces support for overriding the base URL at both the request level and within the `OAuthConfig`.