### PR TITLE
Add allow stray requests method to config

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -49,8 +49,6 @@ final class Config
 
     /**
      * Whether stray requests should be prevented
-     *
-     * @var bool
      */
     private static bool $preventStrayRequests = false;
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -48,6 +48,13 @@ final class Config
     private static ?MiddlewarePipeline $globalMiddlewarePipeline = null;
 
     /**
+     * Whether stray requests should be prevented
+     *
+     * @var bool
+     */
+    private static bool $preventStrayRequests = false;
+
+    /**
      * Write a custom sender resolver
      */
     public static function setSenderResolver(?callable $senderResolver): void
@@ -86,10 +93,20 @@ final class Config
      */
     public static function preventStrayRequests(): void
     {
+        self::$preventStrayRequests = true;
+
         self::globalMiddleware()->onRequest(static function (PendingRequest $pendingRequest) {
-            if (! $pendingRequest->hasMockClient()) {
+            if (self::$preventStrayRequests && ! $pendingRequest->hasMockClient()) {
                 throw new StrayRequestException;
             }
         }, order: PipeOrder::LAST);
+    }
+
+    /**
+     * Allow stray requests without a MockClient.
+     */
+    public static function allowStrayRequests(): void
+    {
+        self::$preventStrayRequests = false;
     }
 }

--- a/src/Http/BaseResource.php
+++ b/src/Http/BaseResource.php
@@ -9,7 +9,7 @@ class BaseResource
     /**
      * Constructor
      */
-    public function __construct(readonly protected Connector $connector)
+    public function __construct(protected readonly Connector $connector)
     {
         //
     }

--- a/tests/Fixtures/Authenticators/CustomOAuthAuthenticator.php
+++ b/tests/Fixtures/Authenticators/CustomOAuthAuthenticator.php
@@ -13,10 +13,10 @@ class CustomOAuthAuthenticator extends AccessTokenAuthenticator
      * Constructor
      */
     public function __construct(
-        readonly public string             $accessToken,
-        readonly public string             $greeting,
-        readonly public ?string            $refreshToken = null,
-        readonly public ?DateTimeImmutable $expiresAt = null,
+        public readonly string             $accessToken,
+        public readonly string             $greeting,
+        public readonly ?string            $refreshToken = null,
+        public readonly ?DateTimeImmutable $expiresAt = null,
     ) {
         //
     }

--- a/tests/Fixtures/Requests/QueryParameterRequest.php
+++ b/tests/Fixtures/Requests/QueryParameterRequest.php
@@ -25,7 +25,7 @@ class QueryParameterRequest extends Request
     /**
      * Constructor
      */
-    public function __construct(readonly public string $endpoint = '/user')
+    public function __construct(public readonly string $endpoint = '/user')
     {
         //
     }

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -84,3 +84,19 @@ test('you can prevent stray api requests', function () {
 
     Config::clearGlobalMiddleware();
 });
+
+test('you can prevent and then allow stray api requests', function () {
+    Config::preventStrayRequests();
+
+    try {
+        TestConnector::make()->send(new UserRequest);
+    } catch (StrayRequestException $e) {
+        expect($e)->toBeInstanceOf(StrayRequestException::class);
+    }
+
+    Config::allowStrayRequests();
+
+    TestConnector::make()->send(new UserRequest);
+
+    Config::clearGlobalMiddleware();
+});


### PR DESCRIPTION
This adds a `Config::allowStrayRequests()` method, which allows stray requests if they had been previously prevented. The naming and behaviour mirrors Laravel's `Http::allowStrayRequests()` method. 

It would be useful, for example, if you wanted to allow tests to hit a local service, but other tests to continue being forced to use mocks.