### PR TITLE
Fix: Use PHP 8.1 in CS Fixer CI workflow

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -24,10 +24,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Run PHP CS Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          args: --config=.php-cs-fixer.dist.php --allow-risky=yes
+          php-version: '8.1'
+          coverage: none
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+      - name: Run PHP CS Fixer
+        run: composer run fix-code
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
## Problem
The previous CI configuration used `oskarstark/php-cs-fixer-ga` Docker image, which was running on
a newer PHP version (likely 8.4). This caused inconsistent code style fixes when compared to
running php-cs-fixer locally on PHP 8.1 (the project's minimum requirement).
## Solution
- Use `shivammathur/setup-php@v2` to explicitly set PHP 8.1
- Install dependencies via composer
- Run php-cs-fixer using the project's own dependency