### PR TITLE
Handle lowercase Content-Type header for JSON and XML

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -494,13 +494,11 @@ class Response
      */
     public function isJson(): bool
     {
-        $contentType = $this->header('Content-Type');
+        $contentType = $this->psrResponse->getHeaderLine('Content-Type');
 
-        if (is_null($contentType)) {
+        if ($contentType === '') {
             return false;
         }
-
-        $contentType = is_array($contentType) ? $contentType[0] : $contentType;
 
         return str_contains($contentType, 'json');
     }
@@ -510,13 +508,11 @@ class Response
      */
     public function isXml(): bool
     {
-        $contentType = $this->header('Content-Type');
+        $contentType = $this->psrResponse->getHeaderLine('Content-Type');
 
-        if (is_null($contentType)) {
+        if ($contentType === '') {
             return false;
         }
-
-        $contentType = is_array($contentType) ? $contentType[0] : $contentType;
 
         return str_contains($contentType, 'xml');
     }

--- a/tests/Unit/ResponseTest.php
+++ b/tests/Unit/ResponseTest.php
@@ -415,6 +415,8 @@ test('can determine if response is JSON', function () {
         MockResponse::make(['foo' => 'bar'], 200, ['Content-Type' => 'application/json']),
         // JSON with charset
         MockResponse::make(['foo' => 'bar'], 200, ['Content-Type' => 'application/json; charset=utf-8']),
+        // JSON with lowercase header (e.g. FastAPI, HTTP/2)
+        MockResponse::make(['foo' => 'bar'], 200, ['content-type' => 'application/json']),
         // Non-JSON content type
         MockResponse::make('plain text', 200, ['Content-Type' => 'text/plain']),
         // No content type
@@ -422,6 +424,9 @@ test('can determine if response is JSON', function () {
     ]);
 
     $connector = connector();
+
+    $response = $connector->send(new UserRequest, $mockClient);
+    expect($response->isJson())->toBeTrue();
 
     $response = $connector->send(new UserRequest, $mockClient);
     expect($response->isJson())->toBeTrue();
@@ -442,6 +447,8 @@ test('can determine if response is XML', function () {
         MockResponse::make('<?xml version="1.0"?><root></root>', 200, ['Content-Type' => 'application/xml']),
         // XML with charset
         MockResponse::make('<?xml version="1.0"?><root></root>', 200, ['Content-Type' => 'text/xml; charset=utf-8']),
+        // XML with lowercase header (e.g. FastAPI, HTTP/2)
+        MockResponse::make('<?xml version="1.0"?><root></root>', 200, ['content-type' => 'application/xml']),
         // Non-XML content type
         MockResponse::make('plain text', 200, ['Content-Type' => 'text/plain']),
         // No content type
@@ -449,6 +456,9 @@ test('can determine if response is XML', function () {
     ]);
 
     $connector = connector();
+
+    $response = $connector->send(new UserRequest, $mockClient);
+    expect($response->isXml())->toBeTrue();
 
     $response = $connector->send(new UserRequest, $mockClient);
     expect($response->isXml())->toBeTrue();


### PR DESCRIPTION
Fixes https://github.com/saloonphp/saloon/issues/533

This has caught me out before